### PR TITLE
Overhauled design with another Stash instance

### DIFF
--- a/plugins/performerSceneCompare/README.md
+++ b/plugins/performerSceneCompare/README.md
@@ -15,13 +15,19 @@ This script is designed to compare local performer scenes with those available o
 
 ## Configuration
 
-  ```
-    LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
-    STASHDB_ENDPOINT = "https://stashdb.org/graphql"
-    LOCAL_API_KEY = "your_local_api_key"  # Replace with your local API key if needed
-    STASHDB_API_KEY = "your_stashdb_api_key"  # Replace with your StashDB API key
+```
+  LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
+  STASHDB_ENDPOINT = "https://stashdb.org/graphql"
+  LOCAL_API_KEY = "your_local_api_key"  # Replace with your local API key if needed
+  STASHDB_API_KEY = "your_stashdb_api_key"  # Replace with your StashDB API key
 ```
 
 ## Usage
 
-The script is designed to be executed as a plugin within Stash. It is triggered by a performer update post hook. 
+The script is designed to be executed as a plugin within Stash. It is triggered by a performer update post hook.
+
+## Development
+
+`pip install pytest`
+
+Required for running the automated tests.

--- a/plugins/performerSceneCompare/README.md
+++ b/plugins/performerSceneCompare/README.md
@@ -1,6 +1,6 @@
 # Performer Scene Compare
 
-This script is designed to compare local performer scenes with those available on StashDB. Any missing scenes will be created in a separate, missing Stash instance.
+This plugin is designed to compare local performer scenes with those available on StashDB. Any missing scenes will be created in a separate, missing Stash instance.
 
 This plugin will not add, modify or delete anything in your main Stash instance. This plugin will read which performers you have tagged to be included in the comparison, get a list of all scenes of those performers from StashDB and create these missing scenes in the separate, missing Stash instance. Now you can easily see from that separate instance which scenes you are missing and you can filter those by site or by tags.
 

--- a/plugins/performerSceneCompare/README.md
+++ b/plugins/performerSceneCompare/README.md
@@ -1,13 +1,11 @@
 # Performer Scene Compare
 
-This script is designed to compare local performer scenes with those available on StashDB. If there are any missing scenes, the script will create these scenes locally, create a new studio for the performer's missing scenes, and associate the missing scenes with the new studio.
+This script is designed to compare local performer scenes with those available on StashDB. Any missing scenes will be created in a separate Stash instance.
 
 ## Features
 
 - Compare local performer scenes with StashDB.
-- Automatically create missing scenes locally.
-- Create a new studio named after the performer for missing scenes.
-- Associate newly created scenes with the new studio.
+- Automatically create missing scenes in a separate Stash instance.
 
 ## Requirements
 
@@ -16,15 +14,32 @@ This script is designed to compare local performer scenes with those available o
 ## Configuration
 
 ```
-  LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
+  LOCAL_GQL_SCHEME = "http"
+  LOCAL_GQL_HOST = "localhost"
+  LOCAL_GQL_PORT = 9999
+  LOCAL_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
+
+  MISSING_GQL_SCHEME = "http"
+  MISSING_GQL_HOST = "localhost"
+  MISSING_GQL_PORT = 6969
+  MISSING_API_KEY = ""  # Leave blank if you don't have credentials on your missing Stash.
+
   STASHDB_ENDPOINT = "https://stashdb.org/graphql"
-  LOCAL_API_KEY = "your_local_api_key"  # Replace with your local API key if needed
   STASHDB_API_KEY = "your_stashdb_api_key"  # Replace with your StashDB API key
+
+  PERFORMER_TAGS = ["Completionist"]  # Performers with these tags will be selected.
+
+  EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.
 ```
 
 ## Usage
 
-The script is designed to be executed as a plugin within Stash. It is triggered by a performer update post hook.
+The script is designed to be executed as a plugin within Stash. It is triggered by:
+
+- Executing "Process performers" task manually. This will create, update and possibly delete missing scenes.
+- Local scene being updated. If a previously missing scene is now found in local Stash, it is deleted from missing Stash.
+
+The separate task for longer running processing is critical for good user experience. For example if performer processing was triggered when a performer is tagged with Completionist, local Stash UI would look like being stuck until all, possibly thousands of scenes for that performer would have been processed.
 
 ## Development
 

--- a/plugins/performerSceneCompare/README.md
+++ b/plugins/performerSceneCompare/README.md
@@ -5,7 +5,8 @@ This script is designed to compare local performer scenes with those available o
 ## Features
 
 - Compare local performer scenes with StashDB.
-- Automatically create missing scenes in a separate Stash instance.
+- Automatically create missing scenes with studios, tags and descriptions in a separate Stash instance for performers tagged with your configured tag (by default Completionist).
+- Missing scenes can be excluded by tags e.g. for avoiding compilations.
 
 ## Requirements
 

--- a/plugins/performerSceneCompare/README.md
+++ b/plugins/performerSceneCompare/README.md
@@ -44,9 +44,3 @@ The script is designed to be executed as a plugin within Stash. It is triggered 
 - Local scene being updated. If a previously missing scene is now found in local Stash, it is deleted from missing Stash.
 
 The separate task for longer running processing is critical for good user experience. For example if performer processing was triggered when a performer is tagged with Completionist, local Stash UI would look like being stuck until all, possibly thousands of scenes for that performer would have been processed.
-
-## Development
-
-`pip install pytest`
-
-Required for running the automated tests.

--- a/plugins/performerSceneCompare/README.md
+++ b/plugins/performerSceneCompare/README.md
@@ -1,12 +1,15 @@
 # Performer Scene Compare
 
-This script is designed to compare local performer scenes with those available on StashDB. Any missing scenes will be created in a separate Stash instance.
+This script is designed to compare local performer scenes with those available on StashDB. Any missing scenes will be created in a separate, missing Stash instance.
+
+This plugin will not add, modify or delete anything in your main Stash instance. This plugin will read which performers you have tagged to be included in the comparison, get a list of all scenes of those performers from StashDB and create these missing scenes in the separate, missing Stash instance. Now you can easily see from that separate instance which scenes you are missing and you can filter those by site or by tags.
 
 ## Features
 
 - Compare local performer scenes with StashDB.
-- Automatically create missing scenes with studios, tags and descriptions in a separate Stash instance for performers tagged with your configured tag (by default Completionist).
+- Automatically create missing scenes with studios, tags and descriptions in a separate, missing Stash instance for performers tagged with your configured tag (by default Completionist).
 - Missing scenes can be excluded by tags e.g. for avoiding compilations.
+- Missing scenes are automatically deleted from the missing Stash instance when you add those to your main Stash.
 
 ## Requirements
 

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -1,10 +1,10 @@
 # config.py
 
 LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
-LOCAL_API_KEY = "" # Leave blank if you don't have credentials on your Stash.
+LOCAL_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 
 MISSING_GQL_ENDPOINT = "http://localhost:6969/graphql"
-MISSING_API_KEY = "" # Leave blank if you don't have credentials on your Stash.
+MISSING_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 
 STASHDB_ENDPOINT = "https://stashdb.org/graphql"
 STASHDB_API_KEY = ""

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -3,13 +3,11 @@
 LOCAL_GQL_SCHEME = "http"
 LOCAL_GQL_HOST = "localhost"
 LOCAL_GQL_PORT = 9999
-LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
 LOCAL_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 
 MISSING_GQL_SCHEME = "http"
 MISSING_GQL_HOST = "localhost"
 MISSING_GQL_PORT = 6969
-MISSING_GQL_ENDPOINT = "http://localhost:6969/graphql"
 MISSING_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 
 STASHDB_ENDPOINT = "https://stashdb.org/graphql"

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -16,6 +16,3 @@ STASHDB_API_KEY = ""
 PERFORMER_TAGS = []  # Performers with these tags will be selected.
 
 EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.
-
-
-EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -1,6 +1,10 @@
 # config.py
 
 LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
+LOCAL_API_KEY = "" # Leave blank if you don't have credentials on your Stash.
+
+MISSING_GQL_ENDPOINT = "http://localhost:6969/graphql"
+MISSING_API_KEY = "" # Leave blank if you don't have credentials on your Stash.
+
 STASHDB_ENDPOINT = "https://stashdb.org/graphql"
 STASHDB_API_KEY = ""
-LOCAL_API_KEY = "" # Leave blank if you don't have credentials on your Stash.

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -14,21 +14,3 @@ STASHDB_ENDPOINT = "https://stashdb.org/graphql"
 STASHDB_API_KEY = ""
 
 EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.
-
-
-LOCAL_GQL_SCHEME = "http"
-LOCAL_GQL_HOST = "localhost"
-LOCAL_GQL_PORT = 9999
-LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
-LOCAL_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJzdGFzaCIsInN1YiI6IkFQSUtleSIsImlhdCI6MTcwOTU0Mzk2Mn0.oQxeczmukk1u-gyfB-S_ucJ-OMYiWtx8pIbU7XdQrdg"  # Leave blank if you don't have credentials on your Stash.
-
-MISSING_GQL_SCHEME = "http"
-MISSING_GQL_HOST = "localhost"
-MISSING_GQL_PORT = 6969
-MISSING_GQL_ENDPOINT = "http://localhost:6969/graphql"
-MISSING_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJzdGFzaCIsInN1YiI6IkFQSUtleSIsImlhdCI6MTcxODE2MjIwMX0.55itivc7LfOl-KKo_SUBKjSIwQCXn-26aavN-BYxqxc"
-
-STASHDB_ENDPOINT = "https://stashdb.org/graphql"
-STASHDB_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiI3ZDc4MWZkNy1hZGIwLTQ5ZDEtOWU3Ni1lMDJjYmQ0ODViNmUiLCJzdWIiOiJBUElLZXkiLCJpYXQiOjE2OTkwOTU3MDN9.acR6aAUcmbNTctQchM6XJioPjZA40qHtm0NoUb4h0PA"
-
-EXCLUDE_TAGS = ["Compilation"]

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -8,3 +8,5 @@ MISSING_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 
 STASHDB_ENDPOINT = "https://stashdb.org/graphql"
 STASHDB_API_KEY = ""
+
+EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -13,4 +13,9 @@ MISSING_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 STASHDB_ENDPOINT = "https://stashdb.org/graphql"
 STASHDB_API_KEY = ""
 
+PERFORMER_TAGS = []  # Performers with these tags will be selected.
+
+EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.
+
+
 EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -16,3 +16,21 @@ STASHDB_ENDPOINT = "https://stashdb.org/graphql"
 STASHDB_API_KEY = ""
 
 EXCLUDE_TAGS = []  # Scenes containing any of these tags will be excluded.
+
+
+LOCAL_GQL_SCHEME = "http"
+LOCAL_GQL_HOST = "localhost"
+LOCAL_GQL_PORT = 9999
+LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
+LOCAL_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJzdGFzaCIsInN1YiI6IkFQSUtleSIsImlhdCI6MTcwOTU0Mzk2Mn0.oQxeczmukk1u-gyfB-S_ucJ-OMYiWtx8pIbU7XdQrdg"  # Leave blank if you don't have credentials on your Stash.
+
+MISSING_GQL_SCHEME = "http"
+MISSING_GQL_HOST = "localhost"
+MISSING_GQL_PORT = 6969
+MISSING_GQL_ENDPOINT = "http://localhost:6969/graphql"
+MISSING_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJzdGFzaCIsInN1YiI6IkFQSUtleSIsImlhdCI6MTcxODE2MjIwMX0.55itivc7LfOl-KKo_SUBKjSIwQCXn-26aavN-BYxqxc"
+
+STASHDB_ENDPOINT = "https://stashdb.org/graphql"
+STASHDB_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiI3ZDc4MWZkNy1hZGIwLTQ5ZDEtOWU3Ni1lMDJjYmQ0ODViNmUiLCJzdWIiOiJBUElLZXkiLCJpYXQiOjE2OTkwOTU3MDN9.acR6aAUcmbNTctQchM6XJioPjZA40qHtm0NoUb4h0PA"
+
+EXCLUDE_TAGS = ["Compilation"]

--- a/plugins/performerSceneCompare/config.py
+++ b/plugins/performerSceneCompare/config.py
@@ -1,8 +1,14 @@
 # config.py
 
+LOCAL_GQL_SCHEME = "http"
+LOCAL_GQL_HOST = "localhost"
+LOCAL_GQL_PORT = 9999
 LOCAL_GQL_ENDPOINT = "http://localhost:9999/graphql"
 LOCAL_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 
+MISSING_GQL_SCHEME = "http"
+MISSING_GQL_HOST = "localhost"
+MISSING_GQL_PORT = 6969
 MISSING_GQL_ENDPOINT = "http://localhost:6969/graphql"
 MISSING_API_KEY = ""  # Leave blank if you don't have credentials on your Stash.
 

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -332,7 +332,7 @@ def get_or_create_missing_performer(performer_name, performer_stash_id):
 
         performer_id = existing_performers[0]["id"]
         logger.debug(
-            f"Missing performer found with stash ID {performer_stash_id} with ID: {performer_id}"
+            f"Performer {performer_name}: Matched with Stash ID {performer_stash_id} to missing Stash ID {performer_id}"
         )
         return performer_id
 
@@ -407,7 +407,7 @@ def process_performer(performer_id: int):
         logger.error("Failed to retrieve details for performer.")
         return
 
-    logger.info(f"Processing performer: {local_performer_details['name']}")
+    logger.info(f"Performer {local_performer_details['name']}: Processing...")
 
     performer_name = local_performer_details["name"]
     performer_stash_id = next(

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -22,12 +22,27 @@ def gql_query(endpoint, query, variables=None, api_key=None):
         logger.error(f"Query failed with status code {response.status_code}: {response.text}")
         return None
 
-def graphql_request(query, variables=None):
+def local_graphql_request(query, variables=None):
     headers = {
         "Accept-Encoding": "gzip, deflate, br",
         "Content-Type": "application/json",
         "Accept": "application/json",
         "ApiKey": config.LOCAL_API_KEY  # Use the local API key if available
+    }
+    response = requests.post(config.LOCAL_GQL_ENDPOINT, json={'query': query, 'variables': variables}, headers=headers)
+    try:
+        data = response.json()
+        return data.get('data')
+    except json.JSONDecodeError:
+        logger.error(f"Failed to decode JSON from response: {response.text}")
+        return None
+
+def missing_graphql_request(query, variables=None):
+    headers = {
+        "Accept-Encoding": "gzip, deflate, br",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "ApiKey": config.MISSING_API_KEY  # Use the local API key if available
     }
     response = requests.post(config.LOCAL_GQL_ENDPOINT, json={'query': query, 'variables': variables}, headers=headers)
     try:
@@ -46,7 +61,7 @@ def get_most_recently_updated_performer():
             }
         }
     """
-    result = graphql_request(query)
+    result = local_graphql_request(query)
     if result and result['allPerformers']:
         # Sort performers by 'updated_at' field in descending order
         sorted_performers = sorted(result['allPerformers'], key=lambda x: x['updated_at'], reverse=True)
@@ -73,7 +88,7 @@ def get_performer_details(performer_id):
             }
         }
     """
-    result = graphql_request(query, {"id": performer_id})
+    result = local_graphql_request(query, {"id": performer_id})
     if result:
         return result['findPerformer']
     logger.error(f"No details found for performer ID {performer_id}.")
@@ -172,7 +187,7 @@ def create_scene(code, title, studio_url, date, cover_image):
             "cover_image": cover_image
         }
     }
-    result = graphql_request(mutation, variables)
+    result = missing_graphql_request(mutation, variables)
     if result and 'sceneCreate' in result:
         scene_id = result['sceneCreate']['id']
         logger.info(f"Scene created with ID: {scene_id}")
@@ -190,7 +205,7 @@ def create_studio(performer_name):
         }
     """
     variables = {"input": {"name": f"{performer_name} - Missing Scenes"}}
-    result = graphql_request(mutation, variables)
+    result = missing_graphql_request(mutation, variables)
     if result and 'studioCreate' in result:
         studio_id = result['studioCreate']['id']
         logger.info(f"Studio created: {performer_name} - Missing Scenes with ID: {studio_id}")
@@ -213,7 +228,7 @@ def update_scene_with_studio(scene_id, studio_id):
             "studio_id": studio_id
         }
     }
-    result = graphql_request(mutation, variables)
+    result = missing_graphql_request(mutation, variables)
     if result and 'sceneUpdate' in result:
         logger.info(f"Scene {scene_id} updated to include studio {studio_id}")
     else:

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -75,27 +75,6 @@ def graphql_request(query, endpoint, api_key, variables=None):
     return None
 
 
-def get_most_recently_updated_performer():
-    query = """
-        query AllPerformers {
-            allPerformers {
-                id
-                updated_at
-            }
-        }
-    """
-    result = local_graphql_request(query)
-    if result and result["allPerformers"]:
-        # Sort performers by 'updated_at' field in descending order
-        sorted_performers = sorted(
-            result["allPerformers"], key=lambda x: x["updated_at"], reverse=True
-        )
-        if sorted_performers:
-            return sorted_performers[0]["id"]
-    logger.error("No performers found.")
-    return None
-
-
 def get_studio_by_name(studio_name):
     query = """
         query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -362,9 +362,7 @@ def find_local_favorite_performers():
     while True:
         performer_filter = {"filter_favorites": True}
         filter = {"page": page, "per_page": 25}
-        logger.debug(f"Performer filter: {performer_filter}\nFilter: {filter}")
         result = local_stash.find_performers(performer_filter, filter)
-        logger.debug(f"Result: {result}")
         performers.extend(result)
         if len(result) < 25:
             break

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -51,53 +51,6 @@ def gql_query(endpoint, query, variables=None, api_key=None):
         return None
 
 
-def local_graphql_request(query, variables=None):
-    return graphql_request(
-        query, config.LOCAL_GQL_ENDPOINT, config.LOCAL_API_KEY, variables
-    )
-
-
-def missing_graphql_request(query, variables=None):
-    return graphql_request(
-        query, config.MISSING_GQL_ENDPOINT, config.MISSING_API_KEY, variables
-    )
-
-
-def graphql_request(query, endpoint, api_key, variables=None):
-    headers = {
-        "Accept-Encoding": "gzip, deflate, br",
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "ApiKey": api_key,  # Use the local API key if available
-    }
-    try:
-        response = requests.post(
-            endpoint,
-            json={"query": query, "variables": variables},
-            headers=headers,
-            timeout=120,  # Set a timeout for the request
-        )
-        logger.trace(
-            f"Request to {endpoint} returned status code {response.status_code}"
-        )
-        response.raise_for_status()  # Raises HTTPError for bad responses (4XX, 5XX)
-        try:
-            data = response.json()
-            return data.get("data")
-        except json.JSONDecodeError:
-            logger.error(f"Failed to decode JSON from response: {response.text}")
-            return None
-    except requests.HTTPError as http_err:
-        logger.error(f"HTTP error occurred: {http_err} - Response: {response.text}")
-    except requests.Timeout:
-        logger.error("The request timed out")
-    except requests.RequestException as err:
-        logger.error(f"Error during requests to {endpoint}: {err}")
-    except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
-    return None
-
-
 def query_stashdb_performer_image(performer_stash_id):
     query = """
         query FindPerformer($id: ID!) {

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -513,9 +513,6 @@ def process_performer(performer_id: int):
 
 
 def compare_performer_scenes():
-    logger.info(f"Local Stash version: {local_stash.version}")
-    logger.info(f"Missing Stash version: {missing_stash.version}")
-
     # json_input = json.loads(sys.stdin.read())
     # logger.debug(f"Input: {json_input}")
 

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -253,9 +253,7 @@ def create_scene(scene, performer_id, studio_id):
             "studio_id": studio_id,
             "performer_ids": [performer_id],
             "cover_image": cover_image,
-            "stash_ids": [
-                {"endpoint": "https://stashdb.org/graphql", "stash_id": stash_id}
-            ],
+            "stash_ids": [{"endpoint": config.STASHDB_ENDPOINT, "stash_id": stash_id}],
         }
     )
 

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -139,6 +139,7 @@ def query_stashdb_scenes(performer_stash_ids):
                 scenes {
                     id
                     title
+                    details
                     release_date
                     urls {
                         url
@@ -258,6 +259,7 @@ def create_scene(scene, performer_id, studio_id):
         {
             "title": title,
             "code": code,
+            "details": scene["details"],
             "url": studio_url,
             "date": formatted_date,
             "studio_id": studio_id,

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -98,30 +98,6 @@ def graphql_request(query, endpoint, api_key, variables=None):
     return None
 
 
-def get_studio_by_name(studio_name):
-    query = """
-        query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {
-            findStudios(filter: $filter, studio_filter: $studio_filter) {
-                count
-                studios {
-                    id
-                    name
-                    parent_studio {
-                        id
-                        name
-                    }
-                }
-            }
-        }
-    """
-    variables = {"filter": {"q": studio_name}}
-    result = missing_graphql_request(query, variables)
-    if result:
-        return result["findStudios"]
-    logger.error(f"No studios found with name {studio_name}.")
-    return None
-
-
 def get_missing_performer_details(performer_id):
     query = """
         query FindPerformer($id: ID!) {

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -208,7 +208,7 @@ def create_scene(scene):
     studio_url = scene["urls"][0]["url"] if scene["urls"] else None
     date = scene["release_date"]
     cover_image = scene["images"][0]["url"] if scene["images"] else None
-    # stash_id=scene['id']
+    stash_id = scene["id"]
 
     try:
         # Ensure the date is in the correct format
@@ -234,12 +234,9 @@ def create_scene(scene):
             "url": studio_url,
             "date": formatted_date,
             "cover_image": cover_image,
-            # "stash_ids": [
-            #     {
-            #         "endpoint": "https://stashdb.org/graphql",
-            #         "stash_id": stash_id
-            #     }
-            # ]
+            "stash_ids": [
+                {"endpoint": "https://stashdb.org/graphql", "stash_id": stash_id}
+            ],
         }
     }
     result = missing_graphql_request(mutation, variables)

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -11,46 +11,62 @@ sys.path.append(script_dir)
 
 import config  # Import the configuration
 
+
 def gql_query(endpoint, query, variables=None, api_key=None):
-    headers = {'Content-Type': 'application/json'}
+    headers = {"Content-Type": "application/json"}
     if api_key:
-        headers['Apikey'] = api_key
-    response = requests.post(endpoint, json={'query': query, 'variables': variables}, headers=headers)
+        headers["Apikey"] = api_key
+    response = requests.post(
+        endpoint, json={"query": query, "variables": variables}, headers=headers
+    )
     if response.status_code == 200:
         return response.json()
     else:
-        logger.error(f"Query failed with status code {response.status_code}: {response.text}")
+        logger.error(
+            f"Query failed with status code {response.status_code}: {response.text}"
+        )
         return None
+
 
 def local_graphql_request(query, variables=None):
     headers = {
         "Accept-Encoding": "gzip, deflate, br",
         "Content-Type": "application/json",
         "Accept": "application/json",
-        "ApiKey": config.LOCAL_API_KEY  # Use the local API key if available
+        "ApiKey": config.LOCAL_API_KEY,  # Use the local API key if available
     }
-    response = requests.post(config.LOCAL_GQL_ENDPOINT, json={'query': query, 'variables': variables}, headers=headers)
+    response = requests.post(
+        config.LOCAL_GQL_ENDPOINT,
+        json={"query": query, "variables": variables},
+        headers=headers,
+    )
     try:
         data = response.json()
-        return data.get('data')
+        return data.get("data")
     except json.JSONDecodeError:
         logger.error(f"Failed to decode JSON from response: {response.text}")
         return None
+
 
 def missing_graphql_request(query, variables=None):
     headers = {
         "Accept-Encoding": "gzip, deflate, br",
         "Content-Type": "application/json",
         "Accept": "application/json",
-        "ApiKey": config.MISSING_API_KEY  # Use the local API key if available
+        "ApiKey": config.MISSING_API_KEY,  # Use the local API key if available
     }
-    response = requests.post(config.LOCAL_GQL_ENDPOINT, json={'query': query, 'variables': variables}, headers=headers)
+    response = requests.post(
+        config.LOCAL_GQL_ENDPOINT,
+        json={"query": query, "variables": variables},
+        headers=headers,
+    )
     try:
         data = response.json()
-        return data.get('data')
+        return data.get("data")
     except json.JSONDecodeError:
         logger.error(f"Failed to decode JSON from response: {response.text}")
         return None
+
 
 def get_most_recently_updated_performer():
     query = """
@@ -62,13 +78,16 @@ def get_most_recently_updated_performer():
         }
     """
     result = local_graphql_request(query)
-    if result and result['allPerformers']:
+    if result and result["allPerformers"]:
         # Sort performers by 'updated_at' field in descending order
-        sorted_performers = sorted(result['allPerformers'], key=lambda x: x['updated_at'], reverse=True)
+        sorted_performers = sorted(
+            result["allPerformers"], key=lambda x: x["updated_at"], reverse=True
+        )
         if sorted_performers:
-            return sorted_performers[0]['id']
+            return sorted_performers[0]["id"]
     logger.error("No performers found.")
     return None
+
 
 def get_performer_details(performer_id):
     query = """
@@ -90,9 +109,10 @@ def get_performer_details(performer_id):
     """
     result = local_graphql_request(query, {"id": performer_id})
     if result:
-        return result['findPerformer']
+        return result["findPerformer"]
     logger.error(f"No details found for performer ID {performer_id}.")
     return None
+
 
 def query_stashdb_scenes(performer_stash_ids):
     query = """
@@ -143,29 +163,44 @@ def query_stashdb_scenes(performer_stash_ids):
     page = 1
     total_scenes = None
     while True:
-        result = gql_query(config.STASHDB_ENDPOINT, query, {"stash_ids": performer_stash_ids, "page": page}, config.STASHDB_API_KEY)
+        result = gql_query(
+            config.STASHDB_ENDPOINT,
+            query,
+            {"stash_ids": performer_stash_ids, "page": page},
+            config.STASHDB_API_KEY,
+        )
         if result:
-            scenes_data = result['data']['queryScenes']
-            scenes.extend(scenes_data['scenes'])
-            total_scenes = total_scenes or scenes_data['count']
-            if len(scenes) >= total_scenes or len(scenes_data['scenes']) < 25:
+            scenes_data = result["data"]["queryScenes"]
+            scenes.extend(scenes_data["scenes"])
+            total_scenes = total_scenes or scenes_data["count"]
+            if len(scenes) >= total_scenes or len(scenes_data["scenes"]) < 25:
                 break
             page += 1
         else:
             break
     return scenes
 
-def compare_scenes(local_scenes, stashdb_scenes):
-    local_scene_ids = {scene['stash_ids'][0]['stash_id'] for scene in local_scenes if scene['stash_ids']}
 
-    missing_scenes = [scene for scene in stashdb_scenes if scene['id'] not in local_scene_ids]
+def compare_scenes(local_scenes, stashdb_scenes):
+    local_scene_ids = {
+        scene["stash_ids"][0]["stash_id"]
+        for scene in local_scenes
+        if scene["stash_ids"]
+    }
+
+    missing_scenes = [
+        scene for scene in stashdb_scenes if scene["id"] not in local_scene_ids
+    ]
     logger.info(f"Found {len(missing_scenes)} missing scenes.")
     return missing_scenes
+
 
 def create_scene(code, title, studio_url, date, cover_image):
     try:
         # Ensure the date is in the correct format
-        formatted_date = datetime.strptime(date, "%Y-%m-%d").date().isoformat() if date else None
+        formatted_date = (
+            datetime.strptime(date, "%Y-%m-%d").date().isoformat() if date else None
+        )
     except ValueError:
         logger.error(f"Invalid date format for scene '{title}': {date}")
         return None
@@ -184,16 +219,17 @@ def create_scene(code, title, studio_url, date, cover_image):
             "title": title,
             "url": studio_url,
             "date": formatted_date,
-            "cover_image": cover_image
+            "cover_image": cover_image,
         }
     }
     result = missing_graphql_request(mutation, variables)
-    if result and 'sceneCreate' in result:
-        scene_id = result['sceneCreate']['id']
+    if result and "sceneCreate" in result:
+        scene_id = result["sceneCreate"]["id"]
         logger.info(f"Scene created with ID: {scene_id}")
         return scene_id
     logger.error(f"Failed to create scene '{title}'")
     return None
+
 
 def create_studio(performer_name):
     mutation = """
@@ -206,12 +242,15 @@ def create_studio(performer_name):
     """
     variables = {"input": {"name": f"{performer_name} - Missing Scenes"}}
     result = missing_graphql_request(mutation, variables)
-    if result and 'studioCreate' in result:
-        studio_id = result['studioCreate']['id']
-        logger.info(f"Studio created: {performer_name} - Missing Scenes with ID: {studio_id}")
+    if result and "studioCreate" in result:
+        studio_id = result["studioCreate"]["id"]
+        logger.info(
+            f"Studio created: {performer_name} - Missing Scenes with ID: {studio_id}"
+        )
         return studio_id
     logger.error(f"Failed to create studio for performer '{performer_name}'")
     return None
+
 
 def update_scene_with_studio(scene_id, studio_id):
     mutation = """
@@ -222,17 +261,13 @@ def update_scene_with_studio(scene_id, studio_id):
             }
         }
     """
-    variables = {
-        "input": {
-            "id": scene_id,
-            "studio_id": studio_id
-        }
-    }
+    variables = {"input": {"id": scene_id, "studio_id": studio_id}}
     result = missing_graphql_request(mutation, variables)
-    if result and 'sceneUpdate' in result:
+    if result and "sceneUpdate" in result:
         logger.info(f"Scene {scene_id} updated to include studio {studio_id}")
     else:
         logger.error(f"Failed to update scene {scene_id} with studio {studio_id}")
+
 
 def compare_performer_scenes():
     performer_id = get_most_recently_updated_performer()
@@ -242,11 +277,13 @@ def compare_performer_scenes():
             logger.info(f"Processing performer: {performer_details['name']}")
 
             # Create a studio for the missing scenes of this performer
-            studio_id = create_studio(performer_details['name'])
-            logger.info(f"Studio created: {performer_details['name']} - Missing Scenes with ID: {studio_id}")
+            studio_id = create_studio(performer_details["name"])
+            logger.info(
+                f"Studio created: {performer_details['name']} - Missing Scenes with ID: {studio_id}"
+            )
 
-            local_scenes = performer_details['scenes']
-            stash_ids = [sid['stash_id'] for sid in performer_details['stash_ids']]
+            local_scenes = performer_details["scenes"]
+            stash_ids = [sid["stash_id"] for sid in performer_details["stash_ids"]]
             stashdb_scenes = query_stashdb_scenes(stash_ids)
             missing_scenes = compare_scenes(local_scenes, stashdb_scenes)
 
@@ -257,28 +294,37 @@ def compare_performer_scenes():
                 for scene in missing_scenes:
                     # Create scene and link it to the new studio
                     created_scene_id = create_scene(
-                        code=scene['code'],
-                        title=scene['title'],
-                        studio_url=scene['urls'][0]['url'] if scene['urls'] else None,
-                        date=scene['release_date'],
-                        cover_image=scene['images'][0]['url'] if scene['images'] else None
+                        code=scene["code"],
+                        title=scene["title"],
+                        studio_url=scene["urls"][0]["url"] if scene["urls"] else None,
+                        date=scene["release_date"],
+                        cover_image=(
+                            scene["images"][0]["url"] if scene["images"] else None
+                        ),
                     )
                     if created_scene_id:
                         update_scene_with_studio(created_scene_id, studio_id)
-                        logger.info(f"Scene {created_scene_id} created and associated with studio {studio_id}")
+                        logger.info(
+                            f"Scene {created_scene_id} created and associated with studio {studio_id}"
+                        )
 
                     # Update progress
                     processed_scenes += 1
                     progress = processed_scenes / total_scenes
                     logger.progress(progress)
 
-                logger.info(f"{total_scenes} missing scenes processed and associated with studio for performer {performer_details['name']}.")
+                logger.info(
+                    f"{total_scenes} missing scenes processed and associated with studio for performer {performer_details['name']}."
+                )
             else:
-                logger.info(f"All scenes for performer {performer_details['name']} are up-to-date with StashDB.")
+                logger.info(
+                    f"All scenes for performer {performer_details['name']} are up-to-date with StashDB."
+                )
         else:
             logger.error("Failed to retrieve details for performer.")
     else:
         logger.error("No recently updated performer found.")
+
 
 if __name__ == "__main__":
     compare_performer_scenes()

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -337,17 +337,17 @@ def get_or_create_missing_performer(performer_name, performer_stash_id):
         return performer_id
 
     image_url = query_stashdb_performer_image(performer_stash_id)
-    logger.debug(f"Performer image URL: {image_url}")
 
-    performer = missing_stash.create_performer(
-        {
-            "name": performer_name,
-            "stash_ids": [
-                {"stash_id": performer_stash_id, "endpoint": config.STASHDB_ENDPOINT}
-            ],
-            "image": image_url,
-        }
-    )
+    performer_in = {
+        "name": performer_name,
+        "stash_ids": [
+            {"stash_id": performer_stash_id, "endpoint": config.STASHDB_ENDPOINT}
+        ],
+    }
+    if image_url:
+        performer_in["image"] = image_url
+
+    performer = missing_stash.create_performer(performer_in)
     if performer:
         logger.info(f"Performer created: {performer_name}")
         return performer["id"]

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -252,7 +252,9 @@ def create_scene(scene, performer_id, studio_id):
             datetime.strptime(date, "%Y-%m-%d").date().isoformat() if date else None
         )
     except ValueError:
-        logger.error(f"Invalid date format for scene '{title}': {date}")
+        logger.error(
+            f"Invalid date format for scene '{title}': {date} (StashDB ID: {stash_id})"
+        )
         return None
 
     result = missing_stash.create_scene(

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -142,7 +142,6 @@ def query_stashdb_scenes(performer_stash_ids):
 
 def compare_scenes(local_scenes, stashdb_scenes):
     local_scene_ids = {scene['stash_ids'][0]['stash_id'] for scene in local_scenes if scene['stash_ids']}
-    stashdb_scene_ids = {scene['id'] for scene in stashdb_scenes}
 
     missing_scenes = [scene for scene in stashdb_scenes if scene['id'] not in local_scene_ids]
     logger.info(f"Found {len(missing_scenes)} missing scenes.")

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -504,7 +504,11 @@ def process_performer(performer_id: int):
     created_scenes_stash_ids = []
     for scene in missing_scenes:
         parent_studio_id = None
-        if scene["studio"] and "parent" in scene["studio"]:
+        if (
+            "studio" in scene
+            and "parent" in scene["studio"]
+            and scene["studio"]["parent"]
+        ):
             parent_studio_id = get_or_create_studio_by_stash_id(
                 scene["studio"]["parent"]
             )

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -238,6 +238,12 @@ def create_scene(scene, performer_id, studio_id):
     date = scene["release_date"]
     cover_image = scene["images"][0]["url"] if scene["images"] else None
     stash_id = scene["id"]
+    tags = scene["tags"]
+    tag_ids = []
+
+    for tag in tags:
+        tag_id = missing_stash.find_tag({"name": tag["name"]}, create=True)
+        tag_ids.append(tag_id["id"])
 
     try:
         # Ensure the date is in the correct format
@@ -256,6 +262,7 @@ def create_scene(scene, performer_id, studio_id):
             "date": formatted_date,
             "studio_id": studio_id,
             "performer_ids": [performer_id],
+            "tag_ids": tag_ids,
             "cover_image": cover_image,
             "stash_ids": [{"endpoint": config.STASHDB_ENDPOINT, "stash_id": stash_id}],
         }

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -418,7 +418,7 @@ def get_or_create_missing_performer(performer_name, performer_stash_id):
 
         performer_id = existing_performers[0]["id"]
         logger.debug(
-            f"Performer found with stash ID {performer_stash_id} with ID: {performer_id}"
+            f"Missing performer found with stash ID {performer_stash_id} with ID: {performer_id}"
         )
         return performer_id
 

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -128,11 +128,13 @@ def get_performer_details(performer_id):
                 name
                 stash_ids {
                     stash_id
+                    endpoint
                 }
                 scenes {
                     title
                     stash_ids {
                         stash_id
+                        endpoint
                     }
                 }
             }
@@ -214,9 +216,10 @@ def query_stashdb_scenes(performer_stash_ids):
 
 def compare_scenes(local_scenes, stashdb_scenes):
     local_scene_ids = {
-        scene["stash_ids"][0]["stash_id"]
+        stash_id["stash_id"]
         for scene in local_scenes
-        if scene["stash_ids"]
+        for stash_id in scene["stash_ids"]
+        if stash_id.get("endpoint") == config.STASHDB_ENDPOINT
     }
 
     missing_scenes = [

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -248,6 +248,10 @@ def query_stashdb_scenes(performer_stash_ids):
                     }
                     duration
                     code
+                    tags {
+                        id
+                        name
+                    }
                 }
                 count
             }
@@ -272,7 +276,15 @@ def query_stashdb_scenes(performer_stash_ids):
             page += 1
         else:
             break
-    return scenes
+
+    filtered_scenes = []
+    for scene in scenes:
+        if scene["tags"]:
+            exclude_tags = config.EXCLUDE_TAGS
+            if not any(tag["name"] in exclude_tags for tag in scene["tags"]):
+                filtered_scenes.append(scene)
+
+    return filtered_scenes
 
 
 def compare_scenes(local_scenes, existing_missing_scenes, stashdb_scenes):

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -509,7 +509,7 @@ def process_performer(
                 ),
                 None,
             )
-            if local_scene_stash_id == existing_missing_scene_stash_id:
+            if scene_stash_id == existing_missing_scene_stash_id:
                 missing_stash.destroy_scene(existing_missing_scene["id"])
                 destroyed_scenes_stash_ids.append(existing_missing_scene_stash_id)
                 logger.debug(

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -407,7 +407,7 @@ def get_or_create_missing_performer(performer_name, performer_stash_id):
     performers = find_performer_by_stash_id(performer_stash_id)
     if performers and performers["count"] > 0:
         performer_id = performers["performers"][0]["id"]
-        logger.info(
+        logger.debug(
             f"Performer found with stash ID {performer_stash_id} with ID: {performer_id}"
         )
         return performer_id
@@ -516,7 +516,7 @@ def find_performer_by_stash_id(performer_stash_id):
             }
         }
     }
-    logger.info(f"Searching for performer with stash ID {performer_stash_id}")
+    logger.debug(f"Searching for performer with stash ID {performer_stash_id}")
     logger.debug(f"Query: {query}")
     logger.debug(f"Query variables: {variables}")
     result = missing_graphql_request(query, variables)

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -590,7 +590,21 @@ def process_updated_scene(stash_id: str):
         logger.debug(f"Scene {scene['title']} (ID: {scene['id']}) destroyed.")
 
 
+def check_stash_instances_are_unique():
+    if (
+        config.LOCAL_GQL_SCHEME == config.MISSING_GQL_SCHEME
+        and config.LOCAL_GQL_HOST == config.MISSING_GQL_HOST
+        and config.LOCAL_GQL_PORT == config.MISSING_GQL_PORT
+    ):
+        logger.error(
+            "Local and missing Stash instances are the same. Please create a different instance for missing Stash."
+        )
+        sys.exit(1)
+
+
 def compare_performer_scenes():
+    check_stash_instances_are_unique()
+
     raw_input = sys.stdin.read()
     json_input = json.loads(raw_input)
     logger.debug(f"Input: {json_input}")

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -54,7 +54,7 @@ def graphql_request(query, endpoint, api_key, variables=None):
             headers=headers,
             timeout=120,  # Set a timeout for the request
         )
-        logger.info(
+        logger.debug(
             f"Request to {endpoint} returned status code {response.status_code}"
         )
         response.raise_for_status()  # Raises HTTPError for bad responses (4XX, 5XX)

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -375,11 +375,20 @@ def get_or_create_missing_performer(performer_name, performer_stash_id):
 
 
 def find_local_favorite_performers():
+    selected_performer_tags = config.PERFORMER_TAGS
+    selected_performer_tag_ids = []
+    for tag in selected_performer_tags:
+        tag_id = local_stash.find_tag({"name": tag})
+        if tag_id:
+            selected_performer_tag_ids.append(tag_id["id"])
+
     performers = []
     page = 1
     logger.debug(f"Searching for local favorite performers...")
     while True:
-        performer_filter = {"filter_favorites": True}
+        performer_filter = {
+            "tags": {"value": selected_performer_tag_ids, "modifier": "INCLUDES"}
+        }
         filter = {"page": page, "per_page": 25}
         result = local_stash.find_performers(performer_filter, filter)
         performers.extend(result)
@@ -387,18 +396,9 @@ def find_local_favorite_performers():
             break
         page += 1
 
-    # TEMP: Only use Kelly Collins
-    filtered_performers = []
-    for performer in performers:
-        stash_ids = performer["stash_ids"]
-        if any(
-            sid["endpoint"] == config.STASHDB_ENDPOINT
-            and sid["stash_id"] == "bfbf1de8-0208-4282-a3cd-7abe2d0588c0"
-            for sid in stash_ids
-        ):
-            filtered_performers.append(performer)
+    return performers
 
-    return filtered_performers
+
 
 
 def process_performer(performer_id: int):

--- a/plugins/performerSceneCompare/performerSceneCompare.py
+++ b/plugins/performerSceneCompare/performerSceneCompare.py
@@ -304,36 +304,35 @@ def compare_performer_scenes():
                 f"Studio created: {performer_details['name']} - Missing Scenes with ID: {studio_id}"
             )
 
-            # local_scenes = performer_details["scenes"]
-            # stash_ids = [sid["stash_id"] for sid in performer_details["stash_ids"]]
-            # stashdb_scenes = query_stashdb_scenes(stash_ids)
-            # missing_scenes = compare_scenes(local_scenes, stashdb_scenes)
-        #
-        # if missing_scenes:
-        #     total_scenes = len(missing_scenes)
-        #     processed_scenes = 0
-        #
-        #     for scene in missing_scenes:
-        #         # Create scene and link it to the new studio
-        #         created_scene_id = create_scene(scene)
-        #         if created_scene_id:
-        #             update_scene_with_studio(created_scene_id, studio_id)
-        #             logger.info(
-        #                 f"Scene {created_scene_id} created and associated with studio {studio_id}"
-        #             )
-        #
-        #         # Update progress
-        #         processed_scenes += 1
-        #         progress = processed_scenes / total_scenes
-        #         logger.progress(progress)
-        #
-        #     logger.info(
-        #         f"{total_scenes} missing scenes processed and associated with studio for performer {performer_details['name']}."
-        #     )
-        # else:
-        #     logger.info(
-        #         f"All scenes for performer {performer_details['name']} are up-to-date with StashDB."
-        #     )
+            local_scenes = performer_details["scenes"]
+            stash_ids = [sid["stash_id"] for sid in performer_details["stash_ids"]]
+            stashdb_scenes = query_stashdb_scenes(stash_ids)
+            missing_scenes = compare_scenes(local_scenes, stashdb_scenes)
+
+            if missing_scenes:
+                total_scenes = len(missing_scenes)
+                processed_scenes = 0
+                for scene in missing_scenes:
+                    # Create scene and link it to the new studio
+                    created_scene_id = create_scene(scene)
+                    if created_scene_id:
+                        update_scene_with_studio(created_scene_id, studio_id)
+                        logger.info(
+                            f"Scene {created_scene_id} created and associated with studio {studio_id}"
+                        )
+
+                        # Update progress
+                        processed_scenes += 1
+                        progress = processed_scenes / total_scenes
+                        logger.progress(progress)
+
+                logger.info(
+                    f"{total_scenes} missing scenes processed and associated with studio for performer {performer_details['name']}."
+                )
+            else:
+                logger.info(
+                    f"All scenes for performer {performer_details['name']} are up-to-date with StashDB."
+                )
         else:
             logger.error("Failed to retrieve details for performer.")
     else:

--- a/plugins/performerSceneCompare/performerSceneCompare.yml
+++ b/plugins/performerSceneCompare/performerSceneCompare.yml
@@ -1,6 +1,6 @@
 name: Performer Scene Compare
 description: Compares local performer scenes with StashDB and updates the local database.
-version: 0.1
+version: 0.1.1
 url: https://github.com/Serechops/Serechops-Stash
 exec:
   - python

--- a/plugins/performerSceneCompare/performerSceneCompare.yml
+++ b/plugins/performerSceneCompare/performerSceneCompare.yml
@@ -1,6 +1,6 @@
 name: Performer Scene Compare
 description: Compares local performer scenes with StashDB and updates the local database.
-version: 0.1.1
+version: 0.2.0
 url: https://github.com/Serechops/Serechops-Stash
 exec:
   - python
@@ -8,9 +8,9 @@ exec:
 interface: raw
 hooks:
   - name: PerformerCompare
-    description: Compares local performer scenes with StashDB on demand.
+    description: Removes scene from missing Stash if a match is found in local Stash.
     triggeredBy:
-      - Performer.Update.Post
+      - Scene.Update.Post
 tasks:
   - name: Process performers
     description: Create missing scenes of performers to another Stash instance

--- a/plugins/performerSceneCompare/performerSceneCompare.yml
+++ b/plugins/performerSceneCompare/performerSceneCompare.yml
@@ -4,11 +4,15 @@ version: 0.1.1
 url: https://github.com/Serechops/Serechops-Stash
 exec:
   - python
-  - "{pluginDir}/performerSceneCompare.py"  # Adjust to your script's name and location
+  - "{pluginDir}/performerSceneCompare.py" # Adjust to your script's name and location
 interface: raw
 hooks:
   - name: PerformerCompare
     description: Compares local performer scenes with StashDB on demand.
     triggeredBy:
       - Performer.Update.Post
-
+tasks:
+  - name: Process performers
+    description: Create missing scenes of performers to another Stash instance
+    defaultArgs:
+      mode: process_performers


### PR DESCRIPTION
# Performer Scene Compare

This plugin is designed to compare local performer scenes with those available on StashDB. Any missing scenes will be created in a separate, missing Stash instance.

This plugin will not add, modify or delete anything in your main Stash instance. This plugin will read which performers you have tagged to be included in the comparison, get a list of all scenes of those performers from StashDB and create these missing scenes in the separate, missing Stash instance. Now you can easily see from that separate instance which scenes you are missing and you can filter those by site or by tags.

## Features

- Compare local performer scenes with StashDB.
- Automatically create missing scenes with studios, tags and descriptions in a separate, missing Stash instance for performers tagged with your configured tag (by default Completionist).
- Missing scenes can be excluded by tags e.g. for avoiding compilations.
- Missing scenes are automatically deleted from the missing Stash instance when you add those to your main Stash.