### PR TITLE
Allow images to be processed on updates and add fallback query for finding performers by matches aliases.

### DIFF
--- a/plugins/stashTagPerformerImage/stashTagPerformerImage.yml
+++ b/plugins/stashTagPerformerImage/stashTagPerformerImage.yml
@@ -11,3 +11,4 @@ hooks:
     description: Updates an image with a relevant performer from a parent directory name check.
     triggeredBy:
       - Image.Create.Post
+      - Image.Update.Post


### PR DESCRIPTION
Only sharing for reference in case you're interested. The parent_directory change is controversial since it is very specific to my instance so probably not wanted/needed.

This supports #18 as I only need to edit an image and hit Apply for it to process. It will return early if a performer is already assigned to avoid recursive updates.

It supports #19 as it will run a subsequent query if finding performer by name fails to return any results.

I've also changed some of the log levels to reduce the number of logged messages visible to info.