### PR TITLE
[stashTagCustomColors] Added coloring to parent tags and marker wall tags

### DIFF
--- a/plugins/stashTagCustomColors/stashTagCustomColors.js
+++ b/plugins/stashTagCustomColors/stashTagCustomColors.js
@@ -44,8 +44,18 @@
 
     // Apply styles to tags
     const applyTagStyles = (tagElement) => {
-        const tagName = tagElement.textContent.trim();
+        const div = tagElement.querySelector("a > div") ?? false;
+        var tagName;
+        if (div) {
+            tagName = div.childNodes[0].textContent.trim();
+        } else {
+            tagName = tagElement.innerText.trim();
+        }
         console.log(`Processing tag: "${tagName}"`);
+
+        // selects the bar and tree icon in parent tagElements (found in the tag page)
+        const verticalLine = tagElement.querySelector("span > span") ?? false;
+        const svg = tagElement.querySelector("path") ?? false;
 
         // Check regex templates first
         for (let template of storedRegexTemplates) {
@@ -63,6 +73,10 @@
                     Object.entries(cssTemplate).forEach(([key, value]) => {
                         tagElement.style[key] = value;
                     });
+                    if (verticalLine) {
+                        verticalLine.style.color = tagElement.style.color;
+                        svg.style.color = tagElement.style.color;
+                    }
                     return; // Style applied
                 } else {
                     console.warn(`CSS template "${template.cssTemplateName}" not found`);
@@ -77,13 +91,17 @@
             tagElement.style.color = "#FFFFFF";
             tagElement.style.borderRadius = "5px";
             tagElement.style.padding = "2px 6px";
+            if (verticalLine) {
+                verticalLine.style.color = tagElement.style.color;
+                svg.style.color = tagElement.style.color;
+            }
         }
     };
 
     // Colorize tags in the DOM
     const colorizeTags = () => {
         requestAnimationFrame(() => {
-            document.querySelectorAll(".react-select__multi-value__label, .tag-item").forEach(tag => {
+            document.querySelectorAll(".react-select__multi-value__label, .tag-item, .wall-tag").forEach(tag => { // added wall-tag from marker walls for completeness
                 applyTagStyles(tag);
             });
         });


### PR DESCRIPTION
Hey Serechops!

Turns out the script you transferred over to a plugin missed out on some fixes I did earlier in the script lifecycle. It currently doesn't color tags that have the parent (tree) icon from the tab page or the Markers wall. This should remedy those I think!

I want to later also add the functionality to make hidden tags and also set up the previous functionality that would help submit to stashbox for those who use a code prefix like in the old script. Thanks so much for your dedication!

-Martie