### PR TITLE
Update stashTagPerformerImage.py - Change the path of the debug log t…

### DIFF
--- a/plugins/stashTagPerformerImage/stashTagPerformerImage.py
+++ b/plugins/stashTagPerformerImage/stashTagPerformerImage.py
@@ -8,7 +8,7 @@ import stashapi.log as log
 # Configure external logger
 external_logger = logging.getLogger('external_logger')
 external_logger.setLevel(logging.DEBUG)
-log_handler = logging.FileHandler('./external_debug.log')
+log_handler = logging.FileHandler('/config/external_debug.log')
 log_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 log_handler.setFormatter(log_formatter)
 external_logger.addHandler(log_handler)


### PR DESCRIPTION
…o an absolute path

Since Stashs config is mapped to /config inside of the container anyway, this can be changed to the absolute path. In Dockers rootless mode this eliminates permission issues with the plugin.

Im not sure though, if this has been fixed since then by Docker perhaps. Discovered this six months ago.