### PR TITLE
sceneSpecsOverlay: overlay format enhancements, optional shadow toggle, and chip opacity tuning

### DIFF
--- a/plugins/sceneSpecsOverlay/README.md
+++ b/plugins/sceneSpecsOverlay/README.md
@@ -19,16 +19,17 @@ A [Stash](https://github.com/stashapp/stash) plugin that keeps the native scene 
 
 ---
 
-## Preview
+## Preview (default)
 
 ```
 ┌─────────────────────────────────────────────────────┐
 │  [scene thumbnail]                                  │
 │                                                     │
-│  [1080p][1:23:45][4.20 GB]                             │
-│  [H264 / AAC][8.5 Mbps][29.97 fps]                     │
+│  [1080p][1:23:45][4.20 GB]                          │
+│  [H264 / AAC][8.5 Mbps][29.97 fps]                  │
 └─────────────────────────────────────────────────────┘
 ```
+
 
 Panel fades in on hover, fades out on mouse leave. Native specs are visible when not hovered.
 
@@ -67,18 +68,36 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
   - Line 2: `VideoCodec/AudioCodec`, `BitRate`, `FPS`
 - Supported tokens:
   - `Resolution`, `Duration`, `FileSize`, `VideoCodec`, `AudioCodec`, `BitRate`, `FPS`
+- Combine values in one chip with `/`:
+  - `[VideoCodec/AudioCodec]` -> `H264 / AAC`
+- Add a line break with either:
+  - `\\n` (escaped newline in a single-line input), or
+  - `[BR]`
 - Suppress token when equal to a value:
   - `[VideoCodec(='AV1')]`
   - `[AudioCodec(='AAC')]`
 
-Examples:
+### Pre-formatted examples
 
-- One-line override:
+- **Default two-line (leave setting blank)**
+  - Line 1: `[Resolution][Duration][FileSize]`
+  - Line 2: `[VideoCodec/AudioCodec][BitRate][FPS]`
+
+- **One-line compact**
   - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
-- Hide AV1 codec:
-  - `[Resolution][Duration][FileSize][VideoCodec(='AV1')][BitRate][FPS]`
-- Include audio codec too:
-  - `[Resolution][Duration][FileSize][VideoCodec][AudioCodec][BitRate][FPS]`
+
+- **One-line with codec combo chip**
+  - `[Resolution][Duration][FileSize][VideoCodec/AudioCodec][BitRate][FPS]`
+
+- **Two-line explicit with `\\n`**
+  - `[Resolution][Duration][FileSize]\\n[VideoCodec/AudioCodec][BitRate][FPS]`
+
+- **Two-line explicit with `[BR]`**
+  - `[Resolution][Duration][FileSize][BR][VideoCodec/AudioCodec][BitRate][FPS]`
+
+- **Hide AV1 while keeping audio in combo**
+  - `[Resolution][Duration][FileSize][VideoCodec(='AV1')/AudioCodec][BitRate][FPS]`
+
 
 If any token is invalid, the plugin logs a warning (`console.warn`) and falls back to the default two-line layout.
 

--- a/plugins/sceneSpecsOverlay/README.md
+++ b/plugins/sceneSpecsOverlay/README.md
@@ -79,25 +79,57 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 
 ### Pre-formatted examples
 
-- **Default two-line (leave setting blank)**
-  - Line 1: `[Resolution][Duration][FileSize]`
-  - Line 2: `[VideoCodec/AudioCodec][BitRate][FPS]`
+**Default two-line (leave setting blank)**
+  `Overlay Format`: *null*
+```
+┌─────────────────────────────────────────────────────┐
+│  scene thumbnail                                    │
+│                                                     │
+│  [1080p][1:23:45][4.20 GB]                          │
+│  [H264 / AAC][8.5 Mbps][29.97 fps]                  │
+└─────────────────────────────────────────────────────┘
+```
 
-- **One-line compact**
+**One-line compact**
   - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
+```
+┌─────────────────────────────────────────────────────┐
+│  scene thumbnail                                    │
+│                                                     │
+│  [1080p][1:23:45][4.20 GB][H264][8.5 Mbps][29.97 fps] │
+└─────────────────────────────────────────────────────┘
+```
 
-- **One-line with codec combo chip**
-  - `[Resolution][Duration][FileSize][VideoCodec/AudioCodec][BitRate][FPS]`
+**One-line with codec combo chip**
+`[Resolution][Duration][FileSize][VideoCodec/AudioCodec][BitRate][FPS]`
+```
+┌─────────────────────────────────────────────────────┐
+│  scene thumbnail                                    │
+│                                                     │
+│  [1080p][1:23:45][4.20 GB][H264 / AAC][8.5 Mbps][29.97 fps] │
+└─────────────────────────────────────────────────────┘
+```
 
-- **Two-line explicit with `\\n`**
-  - `[Resolution][Duration][FileSize]\\n[VideoCodec/AudioCodec][BitRate][FPS]`
-
-- **Two-line explicit with `[BR]`**
+**Two-line explicit with `[BR]`**
   - `[Resolution][Duration][FileSize][BR][VideoCodec/AudioCodec][BitRate][FPS]`
+```
+┌─────────────────────────────────────────────────────┐
+│  scene thumbnail                                    │
+│                                                     │
+│  [1080p][1:23:45][4.20 GB]                          │
+│  [H264 / AAC][8.5 Mbps][29.97 fps]                  │
+└─────────────────────────────────────────────────────┘
+```
 
-- **Hide AV1 while keeping audio in combo**
-  - `[Resolution][Duration][FileSize][VideoCodec(='AV1')/AudioCodec][BitRate][FPS]`
-
+**Hide default codecs in combo**
+  - `[Resolution][Duration][FileSize][VideoCodec(='AV1')/AudioCodec(='AAC')][BitRate][FPS]`
+```
+┌─────────────────────────────────────────────────────┐
+│  scene thumbnail                                    │
+│                                                     │
+│  [1080p][1:23:45][4.20 GB][8.5 Mbps][29.97 fps]     │
+└─────────────────────────────────────────────────────┘
+```
 
 If any token is invalid, the plugin logs a warning (`console.warn`) and falls back to the default two-line layout.
 

--- a/plugins/sceneSpecsOverlay/README.md
+++ b/plugins/sceneSpecsOverlay/README.md
@@ -67,7 +67,7 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
   - Line 1: `Resolution`, `Duration`, `FileSize`
   - Line 2: `VideoCodec/AudioCodec`, `BitRate`, `FPS`
 - Supported tokens:
-  - `Resolution`, `Duration`, `FileSize`, `VideoCodec`, `AudioCodec`, `BitRate`, `FPS`
+  - `Resolution`, `Duration`, `FileSize`, `FileCount`, `VideoCodec`, `AudioCodec`, `BitRate`, `FPS`
 - Combine values in one chip with `/`:
   - `[VideoCodec/AudioCodec]` -> `H264 / AAC`
 - Add a line break with either:
@@ -76,6 +76,7 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 - Suppress token when equal to a value:
   - `[VideoCodec(='AV1')]`
   - `[AudioCodec(='AAC')]`
+  - `[FileCount(=1)]`
 
 ### Pre-formatted examples
 
@@ -111,14 +112,24 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 ```
 
 **Two-line explicit with `[BR]`**
-`[Resolution][Duration][FileSize][BR][VideoCodec/AudioCodec][BitRate][FPS]`
+`[Resolution][Duration][FileSize][FileCount][BR][VideoCodec/AudioCodec][BitRate][FPS]`
 ```
 ┌─────────────────────────────────────────────────────┐
 │  scene thumbnail                                    │
 │                                                     │
-│  [1080p][1:23:45][4.20 GB]                          │
+│  [1080p][1:23:45][4.20 GB][2 Files]                 │
 │  [H264 / AAC][8.5 Mbps][29.97 fps]                  │
 └─────────────────────────────────────────────────────┘
+```
+
+**Suppress FileCount when only one file**
+`[Resolution][Duration][FileSize][FileCount(=1)][VideoCodec][BitRate][FPS]`
+```
+With 1 file:
+[1080p][1:23:45][4.20 GB][H264][8.5 Mbps][29.97 fps]
+
+With 2 files:
+[1080p][1:23:45][4.20 GB][2 Files][H264][8.5 Mbps][29.97 fps]
 ```
 
 **Hide default codecs in combo**

--- a/plugins/sceneSpecsOverlay/README.md
+++ b/plugins/sceneSpecsOverlay/README.md
@@ -1,6 +1,6 @@
 # sceneSpecsOverlay
 
-A [Stash](https://github.com/stashapp/stash) plugin that replaces the native scene specs overlay with a clean, compact at-a-glance panel that fades in when you hover over a scene card.
+A [Stash](https://github.com/stashapp/stash) plugin that keeps the native scene specs overlay by default, then swaps to a custom one-line panel on scene-card hover.
 
 ---
 
@@ -8,36 +8,34 @@ A [Stash](https://github.com/stashapp/stash) plugin that replaces the native sce
 
 - Built entirely with the **PluginApi** — no DOM scraping, no MutationObserver
 - Fades in smoothly on scene card hover via CSS
-- Hides Stash's built-in overlay and renders its own richer replacement
-- **Two-line layout** keeps information dense without clutter:
-  - **Line 1** — Resolution label · Duration · File size
-  - **Line 2** — Video/Audio codec · Bitrate · Frame rate
+- Keeps Stash's built-in overlay visible until hover, then swaps to the plugin overlay
+- **One-line layout** for dense, glanceable metrics:
+  - `Resolution · Duration · File Size · Video Codec · Bitrate · FPS`
 - All data comes directly from `props.scene.files[0]` — no extra GraphQL requests needed
 - Resolution labels match Stash's native conventions (`360p` → `1080p` → `4K` → `8K`)
+- Supports configurable token-based ordering/suppression via `Overlay Format`
 
 ---
 
 ## Preview
 
 ```
-┌─────────────────────────────┐
-│  [scene thumbnail]          │
-│                             │
-│                             │
-│  1080p · 1:23:45 · 4.20 GB  │  ← Line 1
-│  H264 / AAC · 8.5 Mbps · 29.97 fps │  ← Line 2
-└─────────────────────────────┘
+┌─────────────────────────────────────────────────────┐
+│  [scene thumbnail]                                  │
+│                                                     │
+│  [1080p][1:23:45][4.20 GB][H264][8.5 Mbps][29.97 fps] │
+└─────────────────────────────────────────────────────┘
 ```
 
-Panel fades in on hover, fades out on mouse leave.
+Panel fades in on hover, fades out on mouse leave. Native specs are visible when not hovered.
 
 ---
 
 ## Installation
 
 1. Add this index as a new source in your Stash Settings > Plugins > Add Source: [Index](https://serechops.github.io/Serechops-Stash/index.yml)
-
-No configuration required — the plugin works immediately after enabling.
+2. Enable **Stash Scene Specs Overlay**
+3. (Optional) Set `Overlay Format` in plugin settings
 
 ---
 
@@ -55,7 +53,30 @@ No configuration required — the plugin works immediately after enabling.
 
 The plugin uses `PluginApi.patch.after('SceneCard.Overlays', ...)` to append a `SceneSpecsPanel` React component alongside the existing card overlays. The component reads directly from the scene object already present in the card props — specifically `scene.files[0]` which contains all `VideoFile` fields (`video_codec`, `audio_codec`, `frame_rate`, `bit_rate`, `width`, `height`, `duration`, `size`) as part of Stash's standard `SlimSceneData` fragment.
 
-The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and uses `opacity` transition triggered by `.thumbnail-section:hover` — no JavaScript event listeners involved.
+The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and uses `opacity` transition triggered by `.thumbnail-section:hover` — no JavaScript event listeners involved. On hover, native `.scene-specs-overlay` is hidden and the plugin panel is shown.
+
+## Overlay Format setting
+
+`Overlay Format` is a string setting that defines chip order and optional suppression rules.
+
+- If blank, default format is used:
+  - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
+- Supported tokens:
+  - `Resolution`, `Duration`, `FileSize`, `VideoCodec`, `AudioCodec`, `BitRate`, `FPS`
+- Suppress token when equal to a value:
+  - `[VideoCodec(='AV1')]`
+  - `[AudioCodec(='AAC')]`
+
+Examples:
+
+- Default one-line:
+  - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
+- Hide AV1 codec:
+  - `[Resolution][Duration][FileSize][VideoCodec(='AV1')][BitRate][FPS]`
+- Include audio codec too:
+  - `[Resolution][Duration][FileSize][VideoCodec][AudioCodec][BitRate][FPS]`
+
+If any token is invalid, the plugin logs a warning (`console.warn`) and falls back to default format.
 
 ---
 

--- a/plugins/sceneSpecsOverlay/README.md
+++ b/plugins/sceneSpecsOverlay/README.md
@@ -91,27 +91,27 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 ```
 
 **One-line compact**
-  - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
+`[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
 ```
 ┌─────────────────────────────────────────────────────┐
 │  scene thumbnail                                    │
 │                                                     │
-│  [1080p][1:23:45][4.20 GB][H264][8.5 Mbps][29.97 fps] │
+│ [1080p][1:23:45][4.20 GB][H264][8.5 Mbps][29.97 fps]│
 └─────────────────────────────────────────────────────┘
 ```
 
 **One-line with codec combo chip**
 `[Resolution][Duration][FileSize][VideoCodec/AudioCodec][BitRate][FPS]`
 ```
-┌─────────────────────────────────────────────────────┐
-│  scene thumbnail                                    │
-│                                                     │
+┌─────────────────────────────────────────────────────────────┐
+│  scene thumbnail                                            │
+│                                                             │
 │  [1080p][1:23:45][4.20 GB][H264 / AAC][8.5 Mbps][29.97 fps] │
-└─────────────────────────────────────────────────────┘
+└─────────────────────────────────────────────────────────────┘
 ```
 
 **Two-line explicit with `[BR]`**
-  - `[Resolution][Duration][FileSize][BR][VideoCodec/AudioCodec][BitRate][FPS]`
+`[Resolution][Duration][FileSize][BR][VideoCodec/AudioCodec][BitRate][FPS]`
 ```
 ┌─────────────────────────────────────────────────────┐
 │  scene thumbnail                                    │
@@ -122,7 +122,7 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 ```
 
 **Hide default codecs in combo**
-  - `[Resolution][Duration][FileSize][VideoCodec(='AV1')/AudioCodec(='AAC')][BitRate][FPS]`
+`[Resolution][Duration][FileSize][VideoCodec(='AV1')/AudioCodec(='AAC')][BitRate][FPS]`
 ```
 ┌─────────────────────────────────────────────────────┐
 │  scene thumbnail                                    │

--- a/plugins/sceneSpecsOverlay/README.md
+++ b/plugins/sceneSpecsOverlay/README.md
@@ -1,6 +1,6 @@
 # sceneSpecsOverlay
 
-A [Stash](https://github.com/stashapp/stash) plugin that keeps the native scene specs overlay by default, then swaps to a custom one-line panel on scene-card hover.
+A [Stash](https://github.com/stashapp/stash) plugin that keeps the native scene specs overlay by default, then swaps to a custom panel on scene-card hover.
 
 ---
 
@@ -9,8 +9,10 @@ A [Stash](https://github.com/stashapp/stash) plugin that keeps the native scene 
 - Built entirely with the **PluginApi** — no DOM scraping, no MutationObserver
 - Fades in smoothly on scene card hover via CSS
 - Keeps Stash's built-in overlay visible until hover, then swaps to the plugin overlay
-- **One-line layout** for dense, glanceable metrics:
-  - `Resolution · Duration · File Size · Video Codec · Bitrate · FPS`
+- Default plugin panel keeps the original two-line grouping:
+  - **Line 1** — Resolution · Duration · File Size
+  - **Line 2** — Video/Audio Codec · Bitrate · FPS
+- `Overlay Format` can override this to one-line (or any supported token order)
 - All data comes directly from `props.scene.files[0]` — no extra GraphQL requests needed
 - Resolution labels match Stash's native conventions (`360p` → `1080p` → `4K` → `8K`)
 - Supports configurable token-based ordering/suppression via `Overlay Format`
@@ -23,7 +25,8 @@ A [Stash](https://github.com/stashapp/stash) plugin that keeps the native scene 
 ┌─────────────────────────────────────────────────────┐
 │  [scene thumbnail]                                  │
 │                                                     │
-│  [1080p][1:23:45][4.20 GB][H264][8.5 Mbps][29.97 fps] │
+│  [1080p][1:23:45][4.20 GB]                             │
+│  [H264 / AAC][8.5 Mbps][29.97 fps]                     │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -59,8 +62,9 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 
 `Overlay Format` is a string setting that defines chip order and optional suppression rules.
 
-- If blank, default format is used:
-  - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
+- If blank, plugin uses default two-line layout:
+  - Line 1: `Resolution`, `Duration`, `FileSize`
+  - Line 2: `VideoCodec/AudioCodec`, `BitRate`, `FPS`
 - Supported tokens:
   - `Resolution`, `Duration`, `FileSize`, `VideoCodec`, `AudioCodec`, `BitRate`, `FPS`
 - Suppress token when equal to a value:
@@ -69,14 +73,14 @@ The CSS positions the panel absolutely at the bottom of `.thumbnail-section` and
 
 Examples:
 
-- Default one-line:
+- One-line override:
   - `[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]`
 - Hide AV1 codec:
   - `[Resolution][Duration][FileSize][VideoCodec(='AV1')][BitRate][FPS]`
 - Include audio codec too:
   - `[Resolution][Duration][FileSize][VideoCodec][AudioCodec][BitRate][FPS]`
 
-If any token is invalid, the plugin logs a warning (`console.warn`) and falls back to default format.
+If any token is invalid, the plugin logs a warning (`console.warn`) and falls back to the default two-line layout.
 
 ---
 

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -28,6 +28,10 @@
   overflow: hidden;
 }
 
+.sso-panel.sso-panel--no-shadow {
+  background: none;
+}
+
 /* Hover swap:
    - default: native specs visible, custom hidden
    - hover: native hidden, custom shown */

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -78,7 +78,7 @@
   line-height: 1.6;
   padding: 1px 6px;
   border-radius: 3px;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.6);
   border: 1px solid rgba(255, 255, 255, 0.07);
 }
 
@@ -92,7 +92,7 @@
 
 .sso-line--secondary .sso-value {
   font-size: 10px;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(0, 0, 0, 0.6);
   border-color: rgba(255, 255, 255, 0.04);
   opacity: 0.75;
 }

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -39,7 +39,7 @@
   opacity: 1;
 }
 
-.thumbnail-section:hover .scene-specs-overlay {
+:root:not(.sso-display-native-specs) .thumbnail-section:hover .scene-specs-overlay {
   opacity: 0 !important;
   transition: opacity 0.15s ease;
 }

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -1,12 +1,7 @@
 /* =============================================================================
    Scene Specs Overlay — CSS
-   Replaces the native .scene-specs-overlay with a richer slide-up panel.
+   Keeps native specs by default; swaps to custom panel on hover.
    ============================================================================= */
-
-/* Hide Stash's built-in specs overlay (we fully replace it) */
-.scene-specs-overlay {
-  display: none !important;
-}
 
 /* ---------------------------------------------------------------------------
    Panel container
@@ -30,26 +25,35 @@
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.25s ease;
+  overflow: hidden;
 }
 
-/* Trigger: parent thumbnail-section hover */
+/* Hover swap:
+   - default: native specs visible, custom hidden
+   - hover: native hidden, custom shown */
 .thumbnail-section:hover .sso-panel {
   opacity: 1;
 }
 
+.thumbnail-section:hover .scene-specs-overlay {
+  opacity: 0 !important;
+  transition: opacity 0.15s ease;
+}
+
 /* ---------------------------------------------------------------------------
-   Spec area — two lines
+   Spec area — one line
    --------------------------------------------------------------------------- */
 .sso-specs {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-wrap: nowrap;
+  gap: 3px;
+  align-items: center;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
 
-.sso-line {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 3px;
+.sso-specs::-webkit-scrollbar {
+  display: none;
 }
 
 .sso-value {
@@ -72,13 +76,5 @@
   border-color: rgba(100, 180, 255, 0.3);
   color: #90c8f0;
   font-weight: 700;
-}
-
-/* Technical line — slightly smaller and subdued */
-.sso-line--secondary .sso-value {
-  font-size: 10px;
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.04);
-  opacity: 0.75;
 }
 

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -41,9 +41,17 @@
 }
 
 /* ---------------------------------------------------------------------------
-   Spec area — one line
+   Spec area
+   - default (blank Overlay Format): two lines
+   - custom Overlay Format: one line
    --------------------------------------------------------------------------- */
 .sso-specs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sso-line {
   display: flex;
   flex-wrap: nowrap;
   gap: 3px;
@@ -52,7 +60,7 @@
   scrollbar-width: none;
 }
 
-.sso-specs::-webkit-scrollbar {
+.sso-line::-webkit-scrollbar {
   display: none;
 }
 
@@ -76,5 +84,12 @@
   border-color: rgba(100, 180, 255, 0.3);
   color: #90c8f0;
   font-weight: 700;
+}
+
+.sso-line--secondary .sso-value {
+  font-size: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.04);
+  opacity: 0.75;
 }
 

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -78,13 +78,13 @@
   line-height: 1.6;
   padding: 1px 6px;
   border-radius: 3px;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.07);
 }
 
 /* Resolution chip — blue accent */
 .sso-value--res {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.4);
   border-color: rgba(100, 180, 255, 0.3);
   color: #90c8f0;
   font-weight: 700;
@@ -92,7 +92,7 @@
 
 .sso-line--secondary .sso-value {
   font-size: 10px;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.4);
   border-color: rgba(255, 255, 255, 0.04);
   opacity: 0.75;
 }

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.css
@@ -84,7 +84,7 @@
 
 /* Resolution chip — blue accent */
 .sso-value--res {
-  background: rgba(100, 180, 255, 0.18);
+  background: rgba(0, 0, 0, 0.6);
   border-color: rgba(100, 180, 255, 0.3);
   color: #90c8f0;
   font-weight: 700;

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
@@ -5,6 +5,24 @@
   if (!PluginApi) return;
 
   const React = PluginApi.React;
+  const PLUGIN_ID = 'sceneSpecsOverlay';
+  const DEFAULT_FORMAT = '[Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]';
+  const VALID_TOKENS = new Set([
+    'Resolution',
+    'Duration',
+    'FileSize',
+    'VideoCodec',
+    'AudioCodec',
+    'BitRate',
+    'FPS',
+  ]);
+
+  const settingsState = {
+    overlayFormat: '',
+    listeners: new Set(),
+    loaded: false,
+    loading: false,
+  };
 
   // ---------------------------------------------------------------------------
   // Helpers — match Stash's own formatting conventions where possible
@@ -48,7 +66,7 @@
   function fmtSize(bytes) {
     if (!bytes) return null;
     if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
-    if (bytes >= 1048576)    return `${(bytes / 1048576).toFixed(1)} MB`;
+    if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(1)} MB`;
     return `${Math.round(bytes / 1024)} KB`;
   }
 
@@ -65,59 +83,182 @@
     return `${parseFloat(fps.toFixed(2))} fps`;
   }
 
+  function normalizeCodec(codec) {
+    return codec ? String(codec).trim().toUpperCase() : null;
+  }
+
+  function readOverlayFormatFromPlugins(pluginsObj) {
+    if (!pluginsObj || typeof pluginsObj !== 'object') return '';
+    const direct = pluginsObj[PLUGIN_ID];
+    if (direct && typeof direct === 'object') {
+      const v = direct.overlayFormat;
+      return v == null ? '' : String(v);
+    }
+    const key = Object.keys(pluginsObj).find(function (k) {
+      return String(k).toLowerCase() === PLUGIN_ID.toLowerCase();
+    });
+    if (!key) return '';
+    const cfg = pluginsObj[key];
+    if (!cfg || typeof cfg !== 'object') return '';
+    return cfg.overlayFormat == null ? '' : String(cfg.overlayFormat);
+  }
+
+  function notifySettingsListeners() {
+    settingsState.listeners.forEach(function (fn) {
+      try {
+        fn(settingsState.overlayFormat);
+      } catch (e) {
+        // Keep plugin resilient.
+      }
+    });
+  }
+
+  async function loadSettings() {
+    if (settingsState.loading) return;
+    settingsState.loading = true;
+    try {
+      const res = await fetch('/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '{ configuration { plugins } }' }),
+      });
+      if (!res.ok) return;
+      const json = await res.json();
+      const pluginsObj =
+        json && json.data && json.data.configuration && json.data.configuration.plugins;
+      const next = readOverlayFormatFromPlugins(pluginsObj);
+      if (next !== settingsState.overlayFormat || !settingsState.loaded) {
+        settingsState.overlayFormat = next;
+        notifySettingsListeners();
+      }
+      settingsState.loaded = true;
+    } catch (e) {
+      // Keep defaults; do not break UI if settings query fails.
+    } finally {
+      settingsState.loading = false;
+    }
+  }
+
+  function useOverlayFormat() {
+    const useEffect = React.useEffect;
+    const useState = React.useState;
+    const state = useState(settingsState.overlayFormat);
+    const overlayFormat = state[0];
+    const setOverlayFormat = state[1];
+
+    useEffect(function () {
+      function listener(next) {
+        setOverlayFormat(next);
+      }
+      settingsState.listeners.add(listener);
+      if (!settingsState.loaded) loadSettings();
+      return function () {
+        settingsState.listeners.delete(listener);
+      };
+    }, []);
+
+    return overlayFormat;
+  }
+
+  function parseOverlayFormat(raw) {
+    const input = String(raw || '').trim();
+    const format = input || DEFAULT_FORMAT;
+    const re = /\[([^\]]+)\]/g;
+    const tokenExprs = [];
+    let m;
+
+    while ((m = re.exec(format)) !== null) {
+      tokenExprs.push(m[1].trim());
+    }
+
+    if (tokenExprs.length === 0) {
+      throw new Error('No bracketed tokens found.');
+    }
+
+    return tokenExprs.map(function (tokenExpr) {
+      const tm = tokenExpr.match(
+        /^([A-Za-z]+)(?:\(\s*=\s*('([^']*)'|"([^"]*)")\s*\))?$/
+      );
+      if (!tm) {
+        throw new Error('Invalid token syntax: ' + tokenExpr);
+      }
+      const token = tm[1];
+      if (!VALID_TOKENS.has(token)) {
+        throw new Error('Unknown token: ' + token);
+      }
+      const suppressValue =
+        tm[3] != null ? tm[3] : tm[4] != null ? tm[4] : null;
+      return { token: token, suppressValue: suppressValue };
+    });
+  }
+
+  function buildValueMap(file) {
+    return {
+      Resolution: file && file.width && file.height ? resLabel(file.width, file.height) : null,
+      Duration: file ? fmtDuration(file.duration) : null,
+      FileSize: file ? fmtSize(file.size) : null,
+      VideoCodec: file ? normalizeCodec(file.video_codec) : null,
+      AudioCodec: file ? normalizeCodec(file.audio_codec) : null,
+      BitRate: file ? fmtBitrate(file.bit_rate) : null,
+      FPS: file ? fmtFPS(file.frame_rate) : null,
+    };
+  }
+
+  function buildItemsFromFormat(file, overlayFormat) {
+    const valueMap = buildValueMap(file);
+    const specs = parseOverlayFormat(overlayFormat);
+    return specs
+      .map(function (spec) {
+        const value = valueMap[spec.token];
+        if (!value) return null;
+        if (
+          spec.suppressValue != null &&
+          String(value).trim() === String(spec.suppressValue).trim()
+        ) {
+          return null;
+        }
+        return {
+          text: value,
+          className: spec.token === 'Resolution' ? 'sso-value sso-value--res' : 'sso-value',
+        };
+      })
+      .filter(Boolean);
+  }
+
   // ---------------------------------------------------------------------------
   // React component
   // ---------------------------------------------------------------------------
 
   function SceneSpecsPanel({ scene }) {
+    const overlayFormat = useOverlayFormat();
     const file = scene && scene.files && scene.files[0];
+    if (!file) return null;
 
-    // Line 1: resolution · duration · size
-    const line1 = [];
-    // Line 2: codec · bitrate · fps
-    const line2 = [];
-
-    if (file) {
-      if (file.width && file.height) {
-        const label = resLabel(file.width, file.height);
-        if (label) line1.push([label, 'sso-value--res']);
+    let items = [];
+    try {
+      items = buildItemsFromFormat(file, overlayFormat);
+    } catch (err) {
+      if (String(overlayFormat || '').trim().length > 0) {
+        console.warn('[sceneSpecsOverlay] Invalid Overlay Format, using default layout.', {
+          overlayFormat: overlayFormat,
+          error: err && err.message ? err.message : String(err),
+          defaultFormat: DEFAULT_FORMAT,
+        });
       }
-      const dur = fmtDuration(file.duration);
-      if (dur) line1.push(dur);
-      const sz = fmtSize(file.size);
-      if (sz) line1.push(sz);
-
-      if (file.video_codec) {
-        const parts = [file.video_codec, file.audio_codec]
-          .filter(Boolean)
-          .map(function (c) { return c.toUpperCase(); });
-        line2.push(parts.join(' / '));
-      }
-      const br = fmtBitrate(file.bit_rate);
-      if (br) line2.push(br);
-      const fps = fmtFPS(file.frame_rate);
-      if (fps) line2.push(fps);
+      items = buildItemsFromFormat(file, DEFAULT_FORMAT);
     }
 
-    if (line1.length === 0 && line2.length === 0) return null;
-
-    function renderLine(items, lineClass) {
-      return React.createElement(
-        'div', { className: 'sso-line' + (lineClass ? ' ' + lineClass : '') },
-        items.map(function (item, i) {
-          var text = Array.isArray(item) ? item[0] : item;
-          var cls  = Array.isArray(item) ? 'sso-value ' + item[1] : 'sso-value';
-          return React.createElement('span', { className: cls, key: i }, text);
-        })
-      );
-    }
+    if (items.length === 0) return null;
 
     return React.createElement(
-      'div', { className: 'sso-panel' },
+      'div',
+      { className: 'sso-panel' },
       React.createElement(
-        'div', { className: 'sso-specs' },
-        line1.length > 0 && renderLine(line1, ''),
-        line2.length > 0 && renderLine(line2, 'sso-line--secondary')
+        'div',
+        { className: 'sso-specs' },
+        items.map(function (item, i) {
+          return React.createElement('span', { className: item.className, key: i }, item.text);
+        })
       )
     );
   }
@@ -127,13 +268,15 @@
   // ---------------------------------------------------------------------------
 
   PluginApi.patch.after('SceneCard.Overlays', function () {
-    var props  = arguments[0];
+    var props = arguments[0];
     var result = arguments[arguments.length - 1];
     return React.createElement(
-      React.Fragment, null,
+      React.Fragment,
+      null,
       result,
       React.createElement(SceneSpecsPanel, { scene: props.scene })
     );
   });
 
+  loadSettings();
 })();

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
@@ -28,10 +28,6 @@
   // Helpers — match Stash's own formatting conventions where possible
   // ---------------------------------------------------------------------------
 
-  /**
-   * Resolution label matching Stash's TextUtils.resolution() (text.ts).
-   * Uses min(width, height) — same as upstream.
-   */
   function resLabel(w, h) {
     if (!w || !h) return null;
     const n = Math.min(w, h);
@@ -50,7 +46,6 @@
     return `${n}p`;
   }
 
-  /** HH:MM:SS or MM:SS */
   function fmtDuration(secs) {
     if (!secs || secs < 1) return null;
     const h = Math.floor(secs / 3600);
@@ -62,7 +57,6 @@
     return `${m}:${String(s).padStart(2, '0')}`;
   }
 
-  /** Human-readable file size (binary, same as Stash's FileSize component) */
   function fmtSize(bytes) {
     if (!bytes) return null;
     if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
@@ -70,14 +64,12 @@
     return `${Math.round(bytes / 1024)} KB`;
   }
 
-  /** Bitrate in Mbps / Kbps */
   function fmtBitrate(bps) {
     if (!bps) return null;
     if (bps >= 1e6) return `${(bps / 1e6).toFixed(1)} Mbps`;
     return `${Math.round(bps / 1000)} Kbps`;
   }
 
-  /** Frame rate with up to 2 significant decimals */
   function fmtFPS(fps) {
     if (!fps) return null;
     return `${parseFloat(fps.toFixed(2))} fps`;
@@ -162,12 +154,11 @@
 
   function parseOverlayFormat(raw) {
     const input = String(raw || '').trim();
-    const format = input || DEFAULT_FORMAT;
     const re = /\[([^\]]+)\]/g;
     const tokenExprs = [];
     let m;
 
-    while ((m = re.exec(format)) !== null) {
+    while ((m = re.exec(input)) !== null) {
       tokenExprs.push(m[1].trim());
     }
 
@@ -204,7 +195,28 @@
     };
   }
 
-  function buildItemsFromFormat(file, overlayFormat) {
+  function buildLegacyLines(file) {
+    const line1 = [];
+    const line2 = [];
+    if (!file) return [];
+
+    const map = buildValueMap(file);
+    if (map.Resolution) line1.push({ text: map.Resolution, className: 'sso-value sso-value--res' });
+    if (map.Duration) line1.push({ text: map.Duration, className: 'sso-value' });
+    if (map.FileSize) line1.push({ text: map.FileSize, className: 'sso-value' });
+
+    const codecParts = [map.VideoCodec, map.AudioCodec].filter(Boolean);
+    if (codecParts.length) line2.push({ text: codecParts.join(' / '), className: 'sso-value' });
+    if (map.BitRate) line2.push({ text: map.BitRate, className: 'sso-value' });
+    if (map.FPS) line2.push({ text: map.FPS, className: 'sso-value' });
+
+    const lines = [];
+    if (line1.length) lines.push(line1);
+    if (line2.length) lines.push(line2);
+    return lines;
+  }
+
+  function buildCustomLine(file, overlayFormat) {
     const valueMap = buildValueMap(file);
     const specs = parseOverlayFormat(overlayFormat);
     return specs
@@ -225,47 +237,51 @@
       .filter(Boolean);
   }
 
-  // ---------------------------------------------------------------------------
-  // React component
-  // ---------------------------------------------------------------------------
+  function renderLines(lines) {
+    return lines.map(function (line, idx) {
+      const lineCls = idx === 1 ? 'sso-line sso-line--secondary' : 'sso-line';
+      return React.createElement(
+        'div',
+        { className: lineCls, key: idx },
+        line.map(function (item, i) {
+          return React.createElement('span', { className: item.className, key: i }, item.text);
+        })
+      );
+    });
+  }
 
   function SceneSpecsPanel({ scene }) {
     const overlayFormat = useOverlayFormat();
     const file = scene && scene.files && scene.files[0];
     if (!file) return null;
 
-    let items = [];
-    try {
-      items = buildItemsFromFormat(file, overlayFormat);
-    } catch (err) {
-      if (String(overlayFormat || '').trim().length > 0) {
-        console.warn('[sceneSpecsOverlay] Invalid Overlay Format, using default layout.', {
+    let lines = [];
+    const formatInput = String(overlayFormat || '').trim();
+
+    if (formatInput.length === 0) {
+      lines = buildLegacyLines(file);
+    } else {
+      try {
+        const customLine = buildCustomLine(file, formatInput);
+        lines = customLine.length > 0 ? [customLine] : [];
+      } catch (err) {
+        console.warn('[sceneSpecsOverlay] Invalid Overlay Format, using default two-line layout.', {
           overlayFormat: overlayFormat,
           error: err && err.message ? err.message : String(err),
           defaultFormat: DEFAULT_FORMAT,
         });
+        lines = buildLegacyLines(file);
       }
-      items = buildItemsFromFormat(file, DEFAULT_FORMAT);
     }
 
-    if (items.length === 0) return null;
+    if (lines.length === 0) return null;
 
     return React.createElement(
       'div',
       { className: 'sso-panel' },
-      React.createElement(
-        'div',
-        { className: 'sso-specs' },
-        items.map(function (item, i) {
-          return React.createElement('span', { className: item.className, key: i }, item.text);
-        })
-      )
+      React.createElement('div', { className: 'sso-specs' }, renderLines(lines))
     );
   }
-
-  // ---------------------------------------------------------------------------
-  // Patch
-  // ---------------------------------------------------------------------------
 
   PluginApi.patch.after('SceneCard.Overlays', function () {
     var props = arguments[0];

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
@@ -21,6 +21,7 @@
   const settingsState = {
     overlayFormat: '',
     suppressShadow: false,
+    displayNativeSpecs: false,
     listeners: new Set(),
     loaded: false,
     loading: false,
@@ -91,6 +92,7 @@
     const out = {
       overlayFormat: '',
       suppressShadow: false,
+      displayNativeSpecs: false,
     };
     if (!pluginsObj || typeof pluginsObj !== 'object') return out;
     const direct = pluginsObj[PLUGIN_ID];
@@ -98,6 +100,7 @@
       const v = direct.overlayFormat;
       out.overlayFormat = v == null ? '' : String(v);
       out.suppressShadow = Boolean(direct.suppressShadow);
+      out.displayNativeSpecs = Boolean(direct.displayNativeSpecs);
       return out;
     }
     const key = Object.keys(pluginsObj).find(function (k) {
@@ -108,6 +111,7 @@
     if (!cfg || typeof cfg !== 'object') return out;
     out.overlayFormat = cfg.overlayFormat == null ? '' : String(cfg.overlayFormat);
     out.suppressShadow = Boolean(cfg.suppressShadow);
+    out.displayNativeSpecs = Boolean(cfg.displayNativeSpecs);
     return out;
   }
 
@@ -117,6 +121,7 @@
         fn({
           overlayFormat: settingsState.overlayFormat,
           suppressShadow: settingsState.suppressShadow,
+          displayNativeSpecs: settingsState.displayNativeSpecs,
         });
       } catch (e) {
         // Keep plugin resilient.
@@ -141,10 +146,12 @@
       if (
         next.overlayFormat !== settingsState.overlayFormat ||
         next.suppressShadow !== settingsState.suppressShadow ||
+        next.displayNativeSpecs !== settingsState.displayNativeSpecs ||
         !settingsState.loaded
       ) {
         settingsState.overlayFormat = next.overlayFormat;
         settingsState.suppressShadow = next.suppressShadow;
+        settingsState.displayNativeSpecs = next.displayNativeSpecs;
         notifySettingsListeners();
       }
       settingsState.loaded = true;
@@ -161,6 +168,7 @@
     const state = useState({
       overlayFormat: settingsState.overlayFormat,
       suppressShadow: settingsState.suppressShadow,
+      displayNativeSpecs: settingsState.displayNativeSpecs,
     });
     const overlaySettings = state[0];
     const setOverlaySettings = state[1];
@@ -341,8 +349,26 @@
     const overlaySettings = useOverlaySettings();
     const overlayFormat = overlaySettings.overlayFormat;
     const suppressShadow = overlaySettings.suppressShadow;
+    const displayNativeSpecs = overlaySettings.displayNativeSpecs;
+    const useEffect = React.useEffect;
     const file = scene && scene.files && scene.files[0];
     if (!file) return null;
+
+    useEffect(
+      function () {
+        const root = document.documentElement;
+        if (!root) return;
+        if (displayNativeSpecs) {
+          root.classList.add('sso-display-native-specs');
+        } else {
+          root.classList.remove('sso-display-native-specs');
+        }
+        return function () {
+          root.classList.remove('sso-display-native-specs');
+        };
+      },
+      [displayNativeSpecs]
+    );
 
     let lines = [];
     const formatInput = String(overlayFormat || '').trim();

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
@@ -152,34 +152,62 @@
     return overlayFormat;
   }
 
+  function parseSingleTokenExpr(tokenExpr) {
+    const tm = tokenExpr.match(
+      /^([A-Za-z]+)(?:\(\s*=\s*('([^']*)'|"([^"]*)")\s*\))?$/
+    );
+    if (!tm) {
+      throw new Error('Invalid token syntax: ' + tokenExpr);
+    }
+    const token = tm[1];
+    if (!VALID_TOKENS.has(token)) {
+      throw new Error('Unknown token: ' + token);
+    }
+    const suppressValue =
+      tm[3] != null ? tm[3] : tm[4] != null ? tm[4] : null;
+    return { token: token, suppressValue: suppressValue };
+  }
+
   function parseOverlayFormat(raw) {
     const input = String(raw || '').trim();
-    const re = /\[([^\]]+)\]/g;
-    const tokenExprs = [];
-    let m;
+    const normalized = input.replace(/\\n/g, '\n').replace(/\[BR\]/gi, '\n');
+    const lineTexts = normalized
+      .split(/\r?\n/)
+      .map(function (s) {
+        return s.trim();
+      })
+      .filter(Boolean);
 
-    while ((m = re.exec(input)) !== null) {
-      tokenExprs.push(m[1].trim());
-    }
-
-    if (tokenExprs.length === 0) {
+    if (lineTexts.length === 0) {
       throw new Error('No bracketed tokens found.');
     }
 
-    return tokenExprs.map(function (tokenExpr) {
-      const tm = tokenExpr.match(
-        /^([A-Za-z]+)(?:\(\s*=\s*('([^']*)'|"([^"]*)")\s*\))?$/
-      );
-      if (!tm) {
-        throw new Error('Invalid token syntax: ' + tokenExpr);
+    return lineTexts.map(function (lineText) {
+      const re = /\[([^\]]+)\]/g;
+      const groups = [];
+      let m;
+
+      while ((m = re.exec(lineText)) !== null) {
+        const groupExpr = m[1].trim();
+        const partExprs = groupExpr
+          .split('/')
+          .map(function (p) {
+            return p.trim();
+          })
+          .filter(Boolean);
+        if (partExprs.length === 0) {
+          throw new Error('Empty token group: ' + groupExpr);
+        }
+        groups.push({
+          parts: partExprs.map(parseSingleTokenExpr),
+        });
       }
-      const token = tm[1];
-      if (!VALID_TOKENS.has(token)) {
-        throw new Error('Unknown token: ' + token);
+
+      if (groups.length === 0) {
+        throw new Error('No bracketed tokens found on line: ' + lineText);
       }
-      const suppressValue =
-        tm[3] != null ? tm[3] : tm[4] != null ? tm[4] : null;
-      return { token: token, suppressValue: suppressValue };
+
+      return groups;
     });
   }
 
@@ -216,25 +244,43 @@
     return lines;
   }
 
-  function buildCustomLine(file, overlayFormat) {
+  function buildCustomLines(file, overlayFormat) {
     const valueMap = buildValueMap(file);
-    const specs = parseOverlayFormat(overlayFormat);
-    return specs
-      .map(function (spec) {
-        const value = valueMap[spec.token];
-        if (!value) return null;
-        if (
-          spec.suppressValue != null &&
-          String(value).trim() === String(spec.suppressValue).trim()
-        ) {
-          return null;
-        }
-        return {
-          text: value,
-          className: spec.token === 'Resolution' ? 'sso-value sso-value--res' : 'sso-value',
-        };
+    const parsedLines = parseOverlayFormat(overlayFormat);
+    return parsedLines
+      .map(function (lineGroups) {
+        return lineGroups
+          .map(function (group) {
+            const values = group.parts
+              .map(function (part) {
+                const value = valueMap[part.token];
+                if (!value) return null;
+                if (
+                  part.suppressValue != null &&
+                  String(value).trim() === String(part.suppressValue).trim()
+                ) {
+                  return null;
+                }
+                return value;
+              })
+              .filter(Boolean);
+
+            if (values.length === 0) return null;
+
+            const firstToken = group.parts[0] && group.parts[0].token;
+            return {
+              text: values.join(' / '),
+              className:
+                group.parts.length === 1 && firstToken === 'Resolution'
+                  ? 'sso-value sso-value--res'
+                  : 'sso-value',
+            };
+          })
+          .filter(Boolean);
       })
-      .filter(Boolean);
+      .filter(function (line) {
+        return line.length > 0;
+      });
   }
 
   function renderLines(lines) {
@@ -262,8 +308,7 @@
       lines = buildLegacyLines(file);
     } else {
       try {
-        const customLine = buildCustomLine(file, formatInput);
-        lines = customLine.length > 0 ? [customLine] : [];
+        lines = buildCustomLines(file, formatInput);
       } catch (err) {
         console.warn('[sceneSpecsOverlay] Invalid Overlay Format, using default two-line layout.', {
           overlayFormat: overlayFormat,

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
@@ -11,6 +11,7 @@
     'Resolution',
     'Duration',
     'FileSize',
+    'FileCount',
     'VideoCodec',
     'AudioCodec',
     'BitRate',
@@ -73,6 +74,12 @@
   function fmtFPS(fps) {
     if (!fps) return null;
     return `${parseFloat(fps.toFixed(2))} fps`;
+  }
+
+  function fmtFileCount(count) {
+    const n = Number(count);
+    if (!Number.isFinite(n) || n < 1) return null;
+    return `${n} ${n === 1 ? 'File' : 'Files'}`;
   }
 
   function normalizeCodec(codec) {
@@ -154,7 +161,7 @@
 
   function parseSingleTokenExpr(tokenExpr) {
     const tm = tokenExpr.match(
-      /^([A-Za-z]+)(?:\(\s*=\s*('([^']*)'|"([^"]*)")\s*\))?$/
+      /^([A-Za-z]+)(?:\(\s*=\s*(?:'([^']*)'|"([^"]*)"|([^)]+?))\s*\))?$/
     );
     if (!tm) {
       throw new Error('Invalid token syntax: ' + tokenExpr);
@@ -164,7 +171,13 @@
       throw new Error('Unknown token: ' + token);
     }
     const suppressValue =
-      tm[3] != null ? tm[3] : tm[4] != null ? tm[4] : null;
+      tm[2] != null
+        ? tm[2]
+        : tm[3] != null
+          ? tm[3]
+          : tm[4] != null
+            ? String(tm[4]).trim()
+            : null;
     return { token: token, suppressValue: suppressValue };
   }
 
@@ -211,11 +224,13 @@
     });
   }
 
-  function buildValueMap(file) {
+  function buildValueMap(scene, file) {
+    const fileCount = Array.isArray(scene && scene.files) ? scene.files.length : 0;
     return {
       Resolution: file && file.width && file.height ? resLabel(file.width, file.height) : null,
       Duration: file ? fmtDuration(file.duration) : null,
       FileSize: file ? fmtSize(file.size) : null,
+      FileCount: fmtFileCount(fileCount),
       VideoCodec: file ? normalizeCodec(file.video_codec) : null,
       AudioCodec: file ? normalizeCodec(file.audio_codec) : null,
       BitRate: file ? fmtBitrate(file.bit_rate) : null,
@@ -228,7 +243,7 @@
     const line2 = [];
     if (!file) return [];
 
-    const map = buildValueMap(file);
+    const map = buildValueMap(null, file);
     if (map.Resolution) line1.push({ text: map.Resolution, className: 'sso-value sso-value--res' });
     if (map.Duration) line1.push({ text: map.Duration, className: 'sso-value' });
     if (map.FileSize) line1.push({ text: map.FileSize, className: 'sso-value' });
@@ -244,8 +259,10 @@
     return lines;
   }
 
-  function buildCustomLines(file, overlayFormat) {
-    const valueMap = buildValueMap(file);
+  function buildCustomLines(scene, file, overlayFormat) {
+    const valueMap = buildValueMap(scene, file);
+    const fileCount =
+      Array.isArray(scene && scene.files) ? scene.files.length : 0;
     const parsedLines = parseOverlayFormat(overlayFormat);
     return parsedLines
       .map(function (lineGroups) {
@@ -255,11 +272,15 @@
               .map(function (part) {
                 const value = valueMap[part.token];
                 if (!value) return null;
-                if (
-                  part.suppressValue != null &&
-                  String(value).trim() === String(part.suppressValue).trim()
-                ) {
-                  return null;
+                if (part.suppressValue != null) {
+                  const suppress = String(part.suppressValue).trim();
+                  if (part.token === 'FileCount') {
+                    if (String(fileCount) === suppress || String(value).trim() === suppress) {
+                      return null;
+                    }
+                  } else if (String(value).trim() === suppress) {
+                    return null;
+                  }
                 }
                 return value;
               })
@@ -308,7 +329,7 @@
       lines = buildLegacyLines(file);
     } else {
       try {
-        lines = buildCustomLines(file, formatInput);
+        lines = buildCustomLines(scene, file, formatInput);
       } catch (err) {
         console.warn('[sceneSpecsOverlay] Invalid Overlay Format, using default two-line layout.', {
           overlayFormat: overlayFormat,

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.js
@@ -20,6 +20,7 @@
 
   const settingsState = {
     overlayFormat: '',
+    suppressShadow: false,
     listeners: new Set(),
     loaded: false,
     loading: false,
@@ -86,26 +87,37 @@
     return codec ? String(codec).trim().toUpperCase() : null;
   }
 
-  function readOverlayFormatFromPlugins(pluginsObj) {
-    if (!pluginsObj || typeof pluginsObj !== 'object') return '';
+  function readSettingsFromPlugins(pluginsObj) {
+    const out = {
+      overlayFormat: '',
+      suppressShadow: false,
+    };
+    if (!pluginsObj || typeof pluginsObj !== 'object') return out;
     const direct = pluginsObj[PLUGIN_ID];
     if (direct && typeof direct === 'object') {
       const v = direct.overlayFormat;
-      return v == null ? '' : String(v);
+      out.overlayFormat = v == null ? '' : String(v);
+      out.suppressShadow = Boolean(direct.suppressShadow);
+      return out;
     }
     const key = Object.keys(pluginsObj).find(function (k) {
       return String(k).toLowerCase() === PLUGIN_ID.toLowerCase();
     });
-    if (!key) return '';
+    if (!key) return out;
     const cfg = pluginsObj[key];
-    if (!cfg || typeof cfg !== 'object') return '';
-    return cfg.overlayFormat == null ? '' : String(cfg.overlayFormat);
+    if (!cfg || typeof cfg !== 'object') return out;
+    out.overlayFormat = cfg.overlayFormat == null ? '' : String(cfg.overlayFormat);
+    out.suppressShadow = Boolean(cfg.suppressShadow);
+    return out;
   }
 
   function notifySettingsListeners() {
     settingsState.listeners.forEach(function (fn) {
       try {
-        fn(settingsState.overlayFormat);
+        fn({
+          overlayFormat: settingsState.overlayFormat,
+          suppressShadow: settingsState.suppressShadow,
+        });
       } catch (e) {
         // Keep plugin resilient.
       }
@@ -125,9 +137,14 @@
       const json = await res.json();
       const pluginsObj =
         json && json.data && json.data.configuration && json.data.configuration.plugins;
-      const next = readOverlayFormatFromPlugins(pluginsObj);
-      if (next !== settingsState.overlayFormat || !settingsState.loaded) {
-        settingsState.overlayFormat = next;
+      const next = readSettingsFromPlugins(pluginsObj);
+      if (
+        next.overlayFormat !== settingsState.overlayFormat ||
+        next.suppressShadow !== settingsState.suppressShadow ||
+        !settingsState.loaded
+      ) {
+        settingsState.overlayFormat = next.overlayFormat;
+        settingsState.suppressShadow = next.suppressShadow;
         notifySettingsListeners();
       }
       settingsState.loaded = true;
@@ -138,16 +155,19 @@
     }
   }
 
-  function useOverlayFormat() {
+  function useOverlaySettings() {
     const useEffect = React.useEffect;
     const useState = React.useState;
-    const state = useState(settingsState.overlayFormat);
-    const overlayFormat = state[0];
-    const setOverlayFormat = state[1];
+    const state = useState({
+      overlayFormat: settingsState.overlayFormat,
+      suppressShadow: settingsState.suppressShadow,
+    });
+    const overlaySettings = state[0];
+    const setOverlaySettings = state[1];
 
     useEffect(function () {
       function listener(next) {
-        setOverlayFormat(next);
+        setOverlaySettings(next);
       }
       settingsState.listeners.add(listener);
       if (!settingsState.loaded) loadSettings();
@@ -156,7 +176,7 @@
       };
     }, []);
 
-    return overlayFormat;
+    return overlaySettings;
   }
 
   function parseSingleTokenExpr(tokenExpr) {
@@ -318,7 +338,9 @@
   }
 
   function SceneSpecsPanel({ scene }) {
-    const overlayFormat = useOverlayFormat();
+    const overlaySettings = useOverlaySettings();
+    const overlayFormat = overlaySettings.overlayFormat;
+    const suppressShadow = overlaySettings.suppressShadow;
     const file = scene && scene.files && scene.files[0];
     if (!file) return null;
 
@@ -344,7 +366,7 @@
 
     return React.createElement(
       'div',
-      { className: 'sso-panel' },
+      { className: suppressShadow ? 'sso-panel sso-panel--no-shadow' : 'sso-panel' },
       React.createElement('div', { className: 'sso-specs' }, renderLines(lines))
     );
   }

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -10,11 +10,6 @@ settings:
   overlayFormat:
     displayName: Overlay Format
     description: >-
-      Optional custom chip format (blank = default two-line layout). Use bracketed tokens like
-      [Resolution][Duration][FileSize][FileCount][VideoCodec][BitRate][FPS]. You can suppress
-      a token when its value matches using (='VALUE'), e.g. [VideoCodec(='AV1')].
-      For FileCount, [FileCount(=1)] suppresses when exactly one file is present.
-      Use / to combine values in one chip (example: [VideoCodec/AudioCodec]).
-      Use \n or [BR] to create a line break.
+      Optional custom chip format (blank = default). See README for examples.
       If any token is invalid, the default format is used.
     type: STRING

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.8
+version: 1.2.9
 ui:
   javascript:
     - sceneSpecsOverlay.js
@@ -17,4 +17,9 @@ settings:
     displayName: Suppress Shadow
     description: >-
       Removes the dark background gradient behind the custom overlay chips.
+    type: BOOLEAN
+  displayNativeSpecs:
+    displayName: Display Native Resolution and Duration
+    description: >-
+      Keep Stash's native scene resolution/duration overlay visible on hover.
     type: BOOLEAN

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,8 +1,17 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.1
+version: 1.2
 ui:
   javascript:
     - sceneSpecsOverlay.js
   css:
     - sceneSpecsOverlay.css
+settings:
+  overlayFormat:
+    displayName: Overlay Format
+    description: >-
+      Optional one-line chip format (blank = default). Use bracketed tokens like
+      [Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]. You can suppress
+      a token when its value matches using (='VALUE'), e.g. [VideoCodec(='AV1')].
+      If any token is invalid, the default format is used.
+    type: STRING

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.9
+version: 1.2.0
 ui:
   javascript:
     - sceneSpecsOverlay.js

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.6
+version: 1.2.7
 ui:
   javascript:
     - sceneSpecsOverlay.js

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.5
+version: 1.2.6
 ui:
   javascript:
     - sceneSpecsOverlay.js

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.1
+version: 1.2.2
 ui:
   javascript:
     - sceneSpecsOverlay.js
@@ -13,5 +13,7 @@ settings:
       Optional custom chip format (blank = default two-line layout). Use bracketed tokens like
       [Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]. You can suppress
       a token when its value matches using (='VALUE'), e.g. [VideoCodec(='AV1')].
+      Use / to combine values in one chip (example: [VideoCodec/AudioCodec]).
+      Use \n or [BR] to create a line break.
       If any token is invalid, the default format is used.
     type: STRING

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.4
+version: 1.2.5
 ui:
   javascript:
     - sceneSpecsOverlay.js
@@ -13,3 +13,8 @@ settings:
       Optional custom chip format (blank = default). See README for examples.
       If any token is invalid, the default format is used.
     type: STRING
+  suppressShadow:
+    displayName: Suppress Shadow
+    description: >-
+      Removes the dark background gradient behind the custom overlay chips.
+    type: BOOLEAN

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.2
+version: 1.2.3
 ui:
   javascript:
     - sceneSpecsOverlay.js
@@ -11,8 +11,9 @@ settings:
     displayName: Overlay Format
     description: >-
       Optional custom chip format (blank = default two-line layout). Use bracketed tokens like
-      [Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]. You can suppress
+      [Resolution][Duration][FileSize][FileCount][VideoCodec][BitRate][FPS]. You can suppress
       a token when its value matches using (='VALUE'), e.g. [VideoCodec(='AV1')].
+      For FileCount, [FileCount(=1)] suppresses when exactly one file is present.
       Use / to combine values in one chip (example: [VideoCodec/AudioCodec]).
       Use \n or [BR] to create a line break.
       If any token is invalid, the default format is used.

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.3
+version: 1.2.4
 ui:
   javascript:
     - sceneSpecsOverlay.js

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2
+version: 1.2.1
 ui:
   javascript:
     - sceneSpecsOverlay.js
@@ -10,7 +10,7 @@ settings:
   overlayFormat:
     displayName: Overlay Format
     description: >-
-      Optional one-line chip format (blank = default). Use bracketed tokens like
+      Optional custom chip format (blank = default two-line layout). Use bracketed tokens like
       [Resolution][Duration][FileSize][VideoCodec][BitRate][FPS]. You can suppress
       a token when its value matches using (='VALUE'), e.g. [VideoCodec(='AV1')].
       If any token is invalid, the default format is used.

--- a/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
+++ b/plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml
@@ -1,6 +1,6 @@
 name: Stash Scene Specs Overlay
 description: Replaces the native scene specs overlay with a rich at-a-glance panel on hover. Shows resolution, duration, file size, codec, bitrate, FPS.
-version: 1.2.7
+version: 1.2.8
 ui:
   javascript:
     - sceneSpecsOverlay.js


### PR DESCRIPTION
## Summary
- Extends `sceneSpecsOverlay` with configurable overlay formatting and additional display tokens.
- Adds optional `Suppress Shadow` setting to remove the dark panel gradient behind chips.
- Tunes chip styling for consistent readability and visual balance on thumbnails in shadow setting.
- Allows re-instatement of default resolution/duration overlay.

## Why
- Gives users finer control over overlay content and layout without code edits.
- Preserves native card behavior while improving hover-based detail display.
- Improves legibility and consistency of chip visuals across different thumbnail scenes.

## Changes Included
- **Allow restoration of native overlay**
  - Plugin setting allows re-enabling default overlay settings.
  - Behavior of plugin continues as normal on mouse-over.
- **Overlay Format setting**
  - Adds a string format parser for custom chip layouts.
  - Supports tokens in `[]` format (for example `[Resolution]`).
  - Supports multi-value chips with `/` (for example `[VideoCodec/AudioCodec]`).
  - Supports suppression syntax with equality checks (for example `[VideoCodec(='AV1')]`).
  - Supports line breaks via `\n` or `[BR]`.
  - Falls back to default two-line layout when format is blank or invalid.
- **FileCount token**
  - Adds `FileCount` token.
  - Displays as `1 File` or `N Files`.
  - Supports suppression patterns such as `[FileCount(=1)]`.
- **Suppress Shadow setting**
  - Adds boolean setting `suppressShadow` (default off).
  - When enabled, removes the dark overlay gradient background.
- **Chip visual updates**
  - Aligns resolution chip background fill with other chips.
  - Uses 40% black fill (`rgba(0,0,0,0.4)`) for chip backgrounds.

## Version
- Plugin manifest bumped to `1.2.9`.

## Files Changed
- `plugins/sceneSpecsOverlay/sceneSpecsOverlay.js`
- `plugins/sceneSpecsOverlay/sceneSpecsOverlay.css`
- `plugins/sceneSpecsOverlay/sceneSpecsOverlay.yml`
- `plugins/sceneSpecsOverlay/README.md`

## Backward Compatibility
- Existing users with no custom format retain default behavior.
- New settings are optional and default-safe.

## Notes for Maintainer
- This is a UI/UX and configurability enhancement.
- README examples can be refined further before merge if desired.

Made with [Cursor](https://cursor.com) tested by KennyG